### PR TITLE
Further clean up & refactoring + more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ### Overview
 
-This is an [Azure Verified Module](https://aka.ms/avm) that provisions an Azure Machine Learning Workspace, which is a core resource for developing, training, and deploying machine learning models on Azure. Additionally, by setting the `kind` variable to `hub`, this module can also provision an Azure AI Studio, which is an enhanced experience built on top of the Azure Machine Learning Workspace specifically for Generative AI use cases.
+This is an [Azure Verified Module](https://aka.ms/avm) that provisions an Azure Machine Learning Workspace, which is a core resource for developing, training, and deploying machine learning models on Azure. Additionally, by setting the `kind` variable to `Hub`, this module can also provision an Azure AI Studio, which is an enhanced experience built on top of the Azure Machine Learning Workspace specifically for Generative AI use cases. Finally, if the `kind` variable is set to `Project`, this module can provision a AI Studio Project for a Hub workspace.
 
 ### Functionality
 
 * **Azure Machine Learning Workspace:** The default behavior of this module is to create an Azure Machine Learning Workspace, which provides the environment and tools necessary for machine learning tasks.
-* **Azure AI Studio:** If the `kind` variable is set to `hub`, the module provisions an Azure AI Studio instead, offering additional AI capabilities while still leveraging the underlying Azure Machine Learning infrastructure.
+* **Azure AI Studio:** If the `kind` variable is set to `Hub`, the module provisions an Azure AI Studio instead, offering additional AI capabilities while still leveraging the underlying Azure Machine Learning infrastructure.
 
 ### Example Usage
 
@@ -17,17 +17,28 @@ module "ml_workspace" {
   source  = "Azure/avm-res-machinelearningservices-workspace/azurerm"
   version = "x.x.x"
 
-  resource_group = {
-    name = "<resource_group_name>"
-    id   = "<resource_group_id>"
-  }
+  resource_group_name = "<resource_group_name>"
 
   location = "<your_location>"
-  kind     = "hub" # Set to 'hub' for Azure AI Studio, or omit for Azure ML Workspace
+  kind     = "Default" # Omitting this parameter will result in the same outcome
 }
 ```
 
-This will create an Azure Machine Learning Workspace or, if `kind` is set to `hub`, an Azure AI Studio.
+This will create an Azure Machine Learning Workspace.
+
+```hcl
+module "ml_workspace" {
+  source  = "Azure/avm-res-machinelearningservices-workspace/azurerm"
+  version = "x.x.x"
+
+  resource_group_name = "<resource_group_name>"
+
+  location = "<your_location>"
+  kind     = "Hub"
+}
+```
+
+This will create an Azure AI Studio.
 
 <!-- markdownlint-disable MD033 -->
 ## Requirements
@@ -104,7 +115,7 @@ Default: `null`
 
 ### <a name="input_aiservices"></a> [aiservices](#input\_aiservices)
 
-Description: An object describing the Application Insights resource to create or reference. This includes the following properties:
+Description: An object describing the AI Services resource to create or reference. This includes the following properties:
 - `create_new`: (Optional) A flag indicating if a new resource must be created. If set to 'false', both `name` and `resource_group_id` must be provided.
 - `analysis_services_sku`: (Optional) When creating a new resource, this specifies the SKU of the Azure Analysis Services server. Possible values are: `D1`, `B1`, `B2`, `S0`, `S1`, `S2`, `S4`, `S8`, `S9`. Availability may be impacted by region; see https://learn.microsoft.com/en-us/azure/analysis-services/analysis-services-overview#availability-by-region
 - `name`: (Optional) If providing an existing resource, the name of the AI Services to reference
@@ -261,9 +272,6 @@ Default: `false`
 Description: An object describing the Key Vault to create the private endpoint connection to. This includes the following properties:
 - `resource_id` - The resource ID of an existing Key Vault.
 - `create_new` -  A flag indicating if a new resource must be created.
-- `network_acls` - (Optional) An object to configure the Key Vault's network rules
-  - `bypass` - (Optional) Specifies whether traffic is bypassed for AzureServices. Valid options are 'AzureServices' or 'None'.
-  - `default_action` - `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are 'Deny' or 'Allow'. Defaults to 'Deny'.
 - `private_endpoints` - A map of private endpoints to create on a newly created Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
   - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
   - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
@@ -279,10 +287,6 @@ Type:
 object({
     resource_id = optional(string, null)
     create_new  = bool
-    network_acls = optional(object({
-      bypass         = optional(string, null)
-      default_action = optional(string, "Deny")
-    }))
     private_endpoints = optional(map(object({
       name                            = optional(string, null)
       subnet_resource_id              = optional(string, null)
@@ -456,9 +460,6 @@ Description: An object describing the Storage Account. This includes the followi
   - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
   - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
   - `inherit_lock` - (Optional) If set to true, the private endpoint will inherit the lock from the parent resource. Defaults to false.
-- `network_rules` - (Optional) An object to configure the Storage Account's network rules
-  - `bypass` - (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of 'Logging', 'Metrics', 'AzureServices', or `None`.
-  - `default_action` - `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are 'Deny' or 'Allow'. Defaults to 'Deny'.
 - `tags` - (Optional) Tags for the Storage Account resource.
 
 Type:
@@ -476,10 +477,6 @@ object({
       network_interface_name          = optional(string, null)
       inherit_lock                    = optional(bool, false)
     })), {})
-    network_rules = optional(object({
-      bypass         = optional(set(string), [])
-      default_action = optional(string, "Deny")
-    }))
     tags = optional(map(string), null)
   })
 ```
@@ -521,6 +518,22 @@ object({
     resource_group_name = optional(string, null)
   })
 ```
+
+Default: `null`
+
+### <a name="input_workspace_description"></a> [workspace\_description](#input\_workspace\_description)
+
+Description: The description of this workspace.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_workspace_friendly_name"></a> [workspace\_friendly\_name](#input\_workspace\_friendly\_name)
+
+Description: The friendly name for this workspace. This value in mutable.
+
+Type: `string`
 
 Default: `null`
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource.aiservice](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azapi_resource.aiserviceconnection](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azapi_resource.computeinstance](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azapi_resource.hub](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
@@ -119,17 +118,19 @@ Description: An object describing the AI Services resource to create or referenc
 - `analysis_services_sku`: (Optional) When creating a new resource, this specifies the SKU of the Azure Analysis Services server. Possible values are: `D1`, `B1`, `B2`, `S0`, `S1`, `S2`, `S4`, `S8`, `S9`. Availability may be impacted by region; see https://learn.microsoft.com/en-us/azure/analysis-services/analysis-services-overview#availability-by-region
 - `name`: (Optional) If providing an existing resource, the name of the AI Services to reference
 - `resource_group_id`: (Optional) If providing an existing resource, the id of the resource group where the AI Services resource resides
-- `tags` - (Optional) Tags for the AI Services resource.
+- `tags`: (Optional) Tags for the AI Services resource.
+- `create_service_connection`: (Optional) Whether or not to create a service connection between the Workspace resource and AI Services resource.
 
 Type:
 
 ```hcl
 object({
-    create_new            = optional(bool, false)
-    analysis_services_sku = optional(string, "S0")
-    name                  = optional(string, null)
-    resource_group_id     = optional(string, null)
-    tags                  = optional(map(string), null)
+    create_new                = optional(bool, false)
+    analysis_services_sku     = optional(string, "S0")
+    name                      = optional(string, null)
+    resource_group_id         = optional(string, null)
+    tags                      = optional(map(string), null)
+    create_service_connection = optional(bool, false)
   })
 ```
 
@@ -587,6 +588,12 @@ Description: The storage account resource.
 ## Modules
 
 The following Modules are called:
+
+### <a name="module_avm_res_cognitiveservices_account"></a> [avm\_res\_cognitiveservices\_account](#module\_avm\_res\_cognitiveservices\_account)
+
+Source: Azure/avm-res-cognitiveservices-account/azurerm
+
+Version: ~> 0.1
 
 ### <a name="module_avm_res_containerregistry_registry"></a> [avm\_res\_containerregistry\_registry](#module\_avm\_res\_containerregistry\_registry)
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,6 @@ module "ml_workspace" {
 
 This will create an Azure Machine Learning Workspace.
 
-```hcl
-module "ml_workspace" {
-  source  = "Azure/avm-res-machinelearningservices-workspace/azurerm"
-  version = "x.x.x"
-
-  resource_group_name = "<resource_group_name>"
-
-  location = "<your_location>"
-  kind     = "Hub"
-}
-```
-
-This will create an Azure AI Studio.
-
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ This will create an Azure AI Studio.
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (1.14.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (1.15.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (3.115)
 
@@ -59,20 +59,19 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource.aiservice](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/resources/resource) (resource)
-- [azapi_resource.aiserviceconnection](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/resources/resource) (resource)
-- [azapi_resource.computeinstance](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/resources/resource) (resource)
-- [azapi_resource.hub](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/resources/resource) (resource)
-- [azapi_resource.project](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/resources/resource) (resource)
-- [azapi_resource.this](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/resources/resource) (resource)
-- [azurerm_application_insights.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/resources/application_insights) (resource)
+- [azapi_resource.aiservice](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
+- [azapi_resource.aiserviceconnection](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
+- [azapi_resource.computeinstance](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
+- [azapi_resource.hub](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
+- [azapi_resource.project](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
+- [azapi_resource.this](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/resources/management_lock) (resource)
 - [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/resources/private_endpoint) (resource)
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/resources/private_endpoint_application_security_group_association) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/0.3.2/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/uuid) (resource)
-- [azapi_resource.existing_aiservices](https://registry.terraform.io/providers/Azure/azapi/1.14.0/docs/data-sources/resource) (data source)
+- [azapi_resource.existing_aiservices](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/data-sources/resource) (data source)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/data-sources/client_config) (data source)
 - [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/data-sources/client_config) (data source)
 - [azurerm_resource_group.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.115/docs/data-sources/resource_group) (data source)
@@ -148,6 +147,11 @@ Description: An object describing the Application Insights resource to create or
 - `resource_id` - (Optional) The resource ID of an existing Application Insights resource.
 - `create_new` - A flag indicating if a new resource must be created.
 - `tags` - (Optional) Tags for a new Application Insights resource.
+- `log_analytics_workspace - An object describing the Log Analytics Workspace for the Application Insights resource
+  - `resource\_id` - The resource ID of an existing Log Analytics Workspace.
+  - `create\_new` - A flag indicating if a new workspace must be created.
+  - `tags` - (Optional) Tags for the Log Analytics Workspace resource.
+`
 
 Type:
 
@@ -156,6 +160,13 @@ object({
     resource_id = optional(string, null)
     create_new  = bool
     tags        = optional(map(string), null)
+    log_analytics_workspace = optional(object({
+      resource_id = optional(string, null)
+      create_new  = bool
+      tags        = optional(map(string), null)
+      }), {
+      create_new = false
+    })
   })
 ```
 
@@ -163,7 +174,10 @@ Default:
 
 ```json
 {
-  "create_new": false
+  "create_new": false,
+  "log_analytics_workspace": {
+    "create_new": false
+  }
 }
 ```
 
@@ -337,31 +351,6 @@ object({
 
 Default: `null`
 
-### <a name="input_log_analytics_workspace"></a> [log\_analytics\_workspace](#input\_log\_analytics\_workspace)
-
-Description: An object describing the Log Analytics Workspace to create. This includes the following properties:
-- `resource_id` - The resource ID of an existing Log Analytics Workspace.
-- `create_new` - A flag indicating if a new workspace must be created.
-- `tags` - (Optional) Tags for the Log Analytics Workspace resource.
-
-Type:
-
-```hcl
-object({
-    resource_id = optional(string, null)
-    create_new  = bool
-    tags        = optional(map(string), null)
-  })
-```
-
-Default:
-
-```json
-{
-  "create_new": false
-}
-```
-
 ### <a name="input_private_endpoints"></a> [private\_endpoints](#input\_private\_endpoints)
 
 Description: A map of private endpoints to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
@@ -527,7 +516,7 @@ Description: The description of this workspace.
 
 Type: `string`
 
-Default: `null`
+Default: `""`
 
 ### <a name="input_workspace_friendly_name"></a> [workspace\_friendly\_name](#input\_workspace\_friendly\_name)
 
@@ -535,7 +524,7 @@ Description: The friendly name for this workspace. This value in mutable.
 
 Type: `string`
 
-Default: `null`
+Default: `"Workspace"`
 
 ### <a name="input_workspace_managed_network"></a> [workspace\_managed\_network](#input\_workspace\_managed\_network)
 
@@ -609,11 +598,17 @@ Source: Azure/avm-res-containerregistry-registry/azurerm
 
 Version: ~> 0.1
 
+### <a name="module_avm_res_insights_component"></a> [avm\_res\_insights\_component](#module\_avm\_res\_insights\_component)
+
+Source: Azure/avm-res-insights-component/azurerm
+
+Version: ~> 0.1
+
 ### <a name="module_avm_res_keyvault_vault"></a> [avm\_res\_keyvault\_vault](#module\_avm\_res\_keyvault\_vault)
 
 Source: Azure/avm-res-keyvault-vault/azurerm
 
-Version: 0.8.0
+Version: ~> 0.9.1
 
 ### <a name="module_avm_res_log_analytics_workspace"></a> [avm\_res\_log\_analytics\_workspace](#module\_avm\_res\_log\_analytics\_workspace)
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azapi_resource.aiservice](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azapi_resource.aiserviceconnection](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azapi_resource.computeinstance](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
 - [azapi_resource.hub](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
@@ -574,12 +575,6 @@ Description: The storage account resource.
 ## Modules
 
 The following Modules are called:
-
-### <a name="module_avm_res_cognitiveservices_account"></a> [avm\_res\_cognitiveservices\_account](#module\_avm\_res\_cognitiveservices\_account)
-
-Source: Azure/avm-res-cognitiveservices-account/azurerm
-
-Version: ~> 0.1
 
 ### <a name="module_avm_res_containerregistry_registry"></a> [avm\_res\_containerregistry\_registry](#module\_avm\_res\_containerregistry\_registry)
 

--- a/README.md
+++ b/README.md
@@ -147,11 +147,10 @@ Description: An object describing the Application Insights resource to create or
 - `resource_id` - (Optional) The resource ID of an existing Application Insights resource.
 - `create_new` - A flag indicating if a new resource must be created.
 - `tags` - (Optional) Tags for a new Application Insights resource.
-- `log_analytics_workspace - An object describing the Log Analytics Workspace for the Application Insights resource
-  - `resource\_id` - The resource ID of an existing Log Analytics Workspace.
-  - `create\_new` - A flag indicating if a new workspace must be created.
+- `log_analytics_workspace` - An object describing the Log Analytics Workspace for the Application Insights resource
+  - `resource_id` - The resource ID of an existing Log Analytics Workspace.
+  - `create_new` - A flag indicating if a new workspace must be created.
   - `tags` - (Optional) Tags for the Log Analytics Workspace resource.
-`
 
 Type:
 
@@ -174,10 +173,7 @@ Default:
 
 ```json
 {
-  "create_new": false,
-  "log_analytics_workspace": {
-    "create_new": false
-  }
+  "create_new": false
 }
 ```
 

--- a/_header.md
+++ b/_header.md
@@ -2,12 +2,12 @@
 
 ### Overview
 
-This is an [Azure Verified Module](https://aka.ms/avm) that provisions an Azure Machine Learning Workspace, which is a core resource for developing, training, and deploying machine learning models on Azure. Additionally, by setting the `kind` variable to `hub`, this module can also provision an Azure AI Studio, which is an enhanced experience built on top of the Azure Machine Learning Workspace specifically for Generative AI use cases.
+This is an [Azure Verified Module](https://aka.ms/avm) that provisions an Azure Machine Learning Workspace, which is a core resource for developing, training, and deploying machine learning models on Azure. Additionally, by setting the `kind` variable to `Hub`, this module can also provision an Azure AI Studio, which is an enhanced experience built on top of the Azure Machine Learning Workspace specifically for Generative AI use cases. Finally, if the `kind` variable is set to `Project`, this module can provision a AI Studio Project for a Hub workspace.
 
 ### Functionality
 
 * **Azure Machine Learning Workspace:** The default behavior of this module is to create an Azure Machine Learning Workspace, which provides the environment and tools necessary for machine learning tasks.
-* **Azure AI Studio:** If the `kind` variable is set to `hub`, the module provisions an Azure AI Studio instead, offering additional AI capabilities while still leveraging the underlying Azure Machine Learning infrastructure.
+* **Azure AI Studio:** If the `kind` variable is set to `Hub`, the module provisions an Azure AI Studio instead, offering additional AI capabilities while still leveraging the underlying Azure Machine Learning infrastructure.
 
 ### Example Usage
 
@@ -16,14 +16,25 @@ module "ml_workspace" {
   source  = "Azure/avm-res-machinelearningservices-workspace/azurerm"
   version = "x.x.x"
 
-  resource_group = {
-    name = "<resource_group_name>"
-    id   = "<resource_group_id>"
-  }
+  resource_group_name = "<resource_group_name>"
 
   location = "<your_location>"
-  kind     = "hub" # Set to 'hub' for Azure AI Studio, or omit for Azure ML Workspace
+  kind     = "Default" # Omitting this parameter will result in the same outcome
 }
 ```
 
-This will create an Azure Machine Learning Workspace or, if `kind` is set to `hub`, an Azure AI Studio.
+This will create an Azure Machine Learning Workspace.
+
+```hcl
+module "ml_workspace" {
+  source  = "Azure/avm-res-machinelearningservices-workspace/azurerm"
+  version = "x.x.x"
+
+  resource_group_name = "<resource_group_name>"
+
+  location = "<your_location>"
+  kind     = "Hub"
+}
+```
+
+This will create an Azure AI Studio.

--- a/_header.md
+++ b/_header.md
@@ -24,17 +24,3 @@ module "ml_workspace" {
 ```
 
 This will create an Azure Machine Learning Workspace.
-
-```hcl
-module "ml_workspace" {
-  source  = "Azure/avm-res-machinelearningservices-workspace/azurerm"
-  version = "x.x.x"
-
-  resource_group_name = "<resource_group_name>"
-
-  location = "<your_location>"
-  kind     = "Hub"
-}
-```
-
-This will create an Azure AI Studio.

--- a/examples/byo_resources/README.md
+++ b/examples/byo_resources/README.md
@@ -5,7 +5,7 @@ This deploys a public Azure Machine Learning Workspace using existing resources.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -103,11 +103,6 @@ module "azureml" {
     create_new  = false
   }
 
-  log_analytics_workspace = {
-    resource_id = azurerm_log_analytics_workspace.example.id
-    create_new  = false
-  }
-
   application_insights = {
     resource_id = replace(azurerm_application_insights.example.id, "Microsoft.Insights", "Microsoft.insights")
     create_new  = false
@@ -124,7 +119,7 @@ module "azureml" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (3.115.0)
 

--- a/examples/byo_resources/main.tf
+++ b/examples/byo_resources/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -94,11 +94,6 @@ module "azureml" {
 
   container_registry = {
     resource_id = azurerm_container_registry.example.id
-    create_new  = false
-  }
-
-  log_analytics_workspace = {
-    resource_id = azurerm_log_analytics_workspace.example.id
     create_new  = false
   }
 

--- a/examples/byo_resources_ai_studio/README.md
+++ b/examples/byo_resources_ai_studio/README.md
@@ -7,13 +7,13 @@ This deploys a public AI Studio Hub using existing resources. The resource group
 terraform {
   required_version = "~> 1.9"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.115.0"
-    }
     azapi = {
       source  = "Azure/azapi"
       version = "1.15.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.115.0"
     }
   }
 }

--- a/examples/byo_resources_ai_studio/README.md
+++ b/examples/byo_resources_ai_studio/README.md
@@ -1,24 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
-# Azure AI Hub
+# BYO Resources - AI Studio
 
-This deploys the private AI Studio Hub with all possible supporting resources:
-
-- AI Hub workspace (private)
-- Storage Account (private)
-- Key Vault (private)
-- Azure Container Registry (private)
-- App Insights and Log Analytics workspace
-- AI Services + an AI Services Connection to the Hub
-
-The managed VNet is not provisioned by default. In the unprovisioned state, you can see the outbound rules created in the Azure Portal or with the Azure CLI + machine learning extension `az ml workspace outbound-rule list --resource-group $RESOURCE_GROUP --workspace-name $WORKSPACE`. Since all possible provisioned resources are private, this collection should include one of type `PrivateEndpoint` for each of the following:
-
-- Key Vault
-- Storage Account: file (spark enabled)
-- Storage Account: blob (spark enabled)
-- Container Registry
-- The AI Hub Workspace (spark enabled)
-
-After the network is provisioned (either by adding compute or manually provisioning it with [the Azure CLI + machine learning extension](https://learn.microsoft.com/en-us/cli/azure/ml/workspace?view=azure-cli-latest#az-ml-workspace-provision-network)), the private endpoints themselves will be created internally for AI Studio.
+This deploys a public AI Studio Hub using existing resources. The resource group, storage account, key vault, and cognitive services account (AI Services) are all provided to the module.
 
 ```hcl
 terraform {
@@ -27,6 +10,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 3.115.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.15.0"
     }
   }
 }
@@ -49,7 +36,7 @@ module "naming" {
 }
 
 # This is required for resource modules
-resource "azurerm_resource_group" "this" {
+resource "azurerm_resource_group" "example" {
   location = var.location
   name     = module.naming.resource_group.name_unique
 }
@@ -57,6 +44,56 @@ resource "azurerm_resource_group" "this" {
 locals {
   name = module.naming.machine_learning_workspace.name_unique
 }
+
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_storage_account" "example" {
+  account_replication_type = "ZRS"
+  account_tier             = "Standard"
+  location                 = azurerm_resource_group.example.location
+  name                     = module.naming.storage_account.name_unique
+  resource_group_name      = azurerm_resource_group.example.name
+}
+
+resource "azurerm_key_vault" "example" {
+  location            = azurerm_resource_group.example.location
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "standard"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azapi_resource" "aiservice" {
+  type = "Microsoft.CognitiveServices/accounts@2024-04-01-preview"
+  body = jsonencode({
+    properties = {
+      publicNetworkAccess = "Enabled"
+      apiProperties = {
+        statisticsEnabled = false
+      }
+    }
+    sku = {
+      "name" : "S0",
+    }
+    kind = "AIServices"
+  })
+  location               = var.location
+  name                   = module.naming.cognitive_account.name_unique
+  parent_id              = azurerm_resource_group.example.id
+  response_export_values = ["*"]
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+}
+
 
 # This is the module call
 # Do not specify location here due to the randomization above.
@@ -66,44 +103,36 @@ module "aihub" {
   source = "../../"
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location                = azurerm_resource_group.this.location
+  location                = azurerm_resource_group.example.location
   name                    = local.name
-  resource_group_name     = azurerm_resource_group.this.name
-  is_private              = true
+  resource_group_name     = azurerm_resource_group.example.name
   kind                    = "Hub"
-  workspace_friendly_name = "Private AI Studio Hub"
+  workspace_friendly_name = "AI Studio Hub"
   workspace_managed_network = {
-    isolation_mode = "AllowInternetOutbound"
+    isolation_mode = "Disabled"
     spark_ready    = true
   }
 
-  container_registry = {
-    create_new     = true
-    zone_redundant = false
-  }
-
-  key_vault = {
-    create_new = true
-  }
-
-  storage_account = {
-    create_new = true
-  }
-
   aiservices = {
-    create_new                = true
+    create_new                = false
+    name                      = azapi_resource.aiservice.name
+    resource_group_id         = azapi_resource.aiservice.parent_id
     create_service_connection = true
   }
 
-  application_insights = {
-    create_new = true
-    log_analytics_workspace = {
-      create_new = true
-    }
+  key_vault = {
+    create_new  = false
+    resource_id = azurerm_key_vault.example.id
+  }
+
+  storage_account = {
+    create_new  = false
+    resource_id = azurerm_storage_account.example.id
   }
 
   enable_telemetry = var.enable_telemetry
 }
+
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -113,13 +142,19 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (1.15.0)
+
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.115.0)
 
 ## Resources
 
 The following resources are used by this module:
 
-- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azapi_resource.aiservice](https://registry.terraform.io/providers/Azure/azapi/1.15.0/docs/resources/resource) (resource)
+- [azurerm_key_vault.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) (resource)
+- [azurerm_resource_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azurerm_storage_account.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) (resource)
+- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/byo_resources_ai_studio/_footer.md
+++ b/examples/byo_resources_ai_studio/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/byo_resources_ai_studio/_header.md
+++ b/examples/byo_resources_ai_studio/_header.md
@@ -1,0 +1,3 @@
+# BYO Resources - AI Studio
+
+This deploys a public AI Studio Hub using existing resources. The resource group, storage account, key vault, and cognitive services account (AI Services) are all provided to the module.

--- a/examples/byo_resources_ai_studio/main.tf
+++ b/examples/byo_resources_ai_studio/main.tf
@@ -1,0 +1,129 @@
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.15.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.115.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "example" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+}
+
+locals {
+  name = module.naming.machine_learning_workspace.name_unique
+}
+
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_storage_account" "example" {
+  account_replication_type = "ZRS"
+  account_tier             = "Standard"
+  location                 = azurerm_resource_group.example.location
+  name                     = module.naming.storage_account.name_unique
+  resource_group_name      = azurerm_resource_group.example.name
+}
+
+resource "azurerm_key_vault" "example" {
+  location            = azurerm_resource_group.example.location
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "standard"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azapi_resource" "aiservice" {
+  type = "Microsoft.CognitiveServices/accounts@2024-04-01-preview"
+  body = jsonencode({
+    properties = {
+      publicNetworkAccess = "Enabled"
+      apiProperties = {
+        statisticsEnabled = false
+      }
+    }
+    sku = {
+      "name" : "S0",
+    }
+    kind = "AIServices"
+  })
+  location               = var.location
+  name                   = module.naming.cognitive_account.name_unique
+  parent_id              = azurerm_resource_group.example.id
+  response_export_values = ["*"]
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+}
+
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "aihub" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location                = azurerm_resource_group.example.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.example.name
+  kind                    = "Hub"
+  workspace_friendly_name = "AI Studio Hub"
+  workspace_managed_network = {
+    isolation_mode = "Disabled"
+    spark_ready    = true
+  }
+
+  aiservices = {
+    create_new                = false
+    name                      = azapi_resource.aiservice.name
+    resource_group_id         = azapi_resource.aiservice.parent_id
+    create_service_connection = true
+  }
+
+  key_vault = {
+    create_new  = false
+    resource_id = azurerm_key_vault.example.id
+  }
+
+  storage_account = {
+    create_new  = false
+    resource_id = azurerm_storage_account.example.id
+  }
+
+  enable_telemetry = var.enable_telemetry
+}
+

--- a/examples/byo_resources_ai_studio/outputs.tf
+++ b/examples/byo_resources_ai_studio/outputs.tf
@@ -1,0 +1,5 @@
+output "resource" {
+  description = "The AI Studio hub workspace."
+  sensitive   = true
+  value       = module.aihub
+}

--- a/examples/byo_resources_ai_studio/variables.tf
+++ b/examples/byo_resources_ai_studio/variables.tf
@@ -1,0 +1,15 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "location" {
+  type        = string
+  default     = "australiaeast"
+  description = "The location for the resources."
+}

--- a/examples/byovnet_privateendpoints/README.md
+++ b/examples/byovnet_privateendpoints/README.md
@@ -10,7 +10,7 @@ This deploys a VNet and the module with private endpoints:
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -126,10 +126,11 @@ module "azureml" {
   }
   application_insights = {
     create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
   }
-  log_analytics_workspace = {
-    create_new = true
-  }
+
   enable_telemetry = var.enable_telemetry
 }
 ```
@@ -139,7 +140,7 @@ module "azureml" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (3.115)
 

--- a/examples/byovnet_privateendpoints/main.tf
+++ b/examples/byovnet_privateendpoints/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -115,9 +115,10 @@ module "azureml" {
   }
   application_insights = {
     create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
   }
-  log_analytics_workspace = {
-    create_new = true
-  }
+
   enable_telemetry = var.enable_telemetry
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -10,7 +10,7 @@ This deploys the module in its simplest form:
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -63,10 +63,11 @@ module "azureml" {
   resource_group_name = azurerm_resource_group.this.name
   application_insights = {
     create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
   }
-  log_analytics_workspace = {
-    create_new = true
-  }
+
   enable_telemetry = var.enable_telemetry
 }
 ```
@@ -76,7 +77,7 @@ module "azureml" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -52,9 +52,10 @@ module "azureml" {
   resource_group_name = azurerm_resource_group.this.name
   application_insights = {
     create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
   }
-  log_analytics_workspace = {
-    create_new = true
-  }
+
   enable_telemetry = var.enable_telemetry
 }

--- a/examples/default_ai_studio/README.md
+++ b/examples/default_ai_studio/README.md
@@ -1,0 +1,145 @@
+<!-- BEGIN_TF_DOCS -->
+# Default AI Studio example
+
+This deploys the module in its simplest form:
+
+- AI Studio hub (public access)
+- Storage Account
+- Key Vault
+- AI Services
+
+```hcl
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.115.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+}
+
+locals {
+  name = module.naming.machine_learning_workspace.name_unique
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "aihub" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location                = azurerm_resource_group.this.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.this.name
+  kind                    = "Hub"
+  workspace_friendly_name = "AI Studio Hub"
+  workspace_managed_network = {
+    isolation_mode = "Disabled"
+    spark_ready    = true
+  }
+
+  aiservices = {
+    create_new = true
+  }
+
+  enable_telemetry = var.enable_telemetry
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.115.0)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: The location for the resources.
+
+Type: `string`
+
+Default: `"australiaeast"`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The AI Studio hub workspace.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_aihub"></a> [aihub](#module\_aihub)
+
+Source: ../../
+
+Version:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.3
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/default_ai_studio/README.md
+++ b/examples/default_ai_studio/README.md
@@ -65,7 +65,8 @@ module "aihub" {
   }
 
   aiservices = {
-    create_new = true
+    create_new                = true
+    create_service_connection = true
   }
 
   enable_telemetry = var.enable_telemetry

--- a/examples/default_ai_studio/_footer.md
+++ b/examples/default_ai_studio/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/default_ai_studio/_header.md
+++ b/examples/default_ai_studio/_header.md
@@ -1,0 +1,8 @@
+# Default AI Studio example
+
+This deploys the module in its simplest form:
+
+- AI Studio hub (public access)
+- Storage Account
+- Key Vault
+- AI Services

--- a/examples/default_ai_studio/main.tf
+++ b/examples/default_ai_studio/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.115.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+}
+
+locals {
+  name = module.naming.machine_learning_workspace.name_unique
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "aihub" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location                = azurerm_resource_group.this.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.this.name
+  kind                    = "Hub"
+  workspace_friendly_name = "AI Studio Hub"
+  workspace_managed_network = {
+    isolation_mode = "Disabled"
+    spark_ready    = true
+  }
+
+  aiservices = {
+    create_new = true
+  }
+
+  enable_telemetry = var.enable_telemetry
+}

--- a/examples/default_ai_studio/main.tf
+++ b/examples/default_ai_studio/main.tf
@@ -54,7 +54,8 @@ module "aihub" {
   }
 
   aiservices = {
-    create_new = true
+    create_new                = true
+    create_service_connection = true
   }
 
   enable_telemetry = var.enable_telemetry

--- a/examples/default_ai_studio/outputs.tf
+++ b/examples/default_ai_studio/outputs.tf
@@ -1,0 +1,5 @@
+output "resource" {
+  description = "The AI Studio hub workspace."
+  sensitive   = true
+  value       = module.aihub
+}

--- a/examples/default_ai_studio/variables.tf
+++ b/examples/default_ai_studio/variables.tf
@@ -1,0 +1,15 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "location" {
+  type        = string
+  default     = "australiaeast"
+  description = "The location for the resources."
+}

--- a/examples/private_ai_studio/README.md
+++ b/examples/private_ai_studio/README.md
@@ -83,18 +83,10 @@ module "aihub" {
 
   key_vault = {
     create_new = true
-    network_acls = {
-      bypass         = "AzureServices"
-      default_action = "Deny"
-    }
   }
 
   storage_account = {
     create_new = true
-    network_rules = {
-      bypass         = ["Logging", "Metrics", "AzureServices"]
-      default_action = "Deny"
-    }
   }
 
   aiservices = {
@@ -157,7 +149,11 @@ Default: `"australiaeast"`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The AI Studio hub workspace.
 
 ## Modules
 

--- a/examples/private_ai_studio/README.md
+++ b/examples/private_ai_studio/README.md
@@ -22,7 +22,7 @@ After the network is provisioned (either by adding compute or manually provision
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -66,11 +66,12 @@ module "aihub" {
   source = "../../"
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = local.name
-  resource_group_name = azurerm_resource_group.this.name
-  is_private          = true
-  kind                = "Hub"
+  location                = azurerm_resource_group.this.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.this.name
+  is_private              = true
+  kind                    = "Hub"
+  workspace_friendly_name = "Private AI Studio Hub"
   workspace_managed_network = {
     isolation_mode = "AllowInternetOutbound"
     spark_ready    = true
@@ -95,10 +96,9 @@ module "aihub" {
 
   application_insights = {
     create_new = true
-  }
-
-  log_analytics_workspace = {
-    create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
   }
 
   enable_telemetry = var.enable_telemetry
@@ -110,7 +110,7 @@ module "aihub" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.115.0)
 

--- a/examples/private_ai_studio/main.tf
+++ b/examples/private_ai_studio/main.tf
@@ -68,7 +68,8 @@ module "aihub" {
   }
 
   aiservices = {
-    create_new = true
+    create_new                = true
+    create_service_connection = true
   }
 
   application_insights = {

--- a/examples/private_ai_studio/main.tf
+++ b/examples/private_ai_studio/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -43,11 +43,12 @@ module "aihub" {
   source = "../../"
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = local.name
-  resource_group_name = azurerm_resource_group.this.name
-  is_private          = true
-  kind                = "Hub"
+  location                = azurerm_resource_group.this.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.this.name
+  is_private              = true
+  kind                    = "Hub"
+  workspace_friendly_name = "Private AI Studio Hub"
   workspace_managed_network = {
     isolation_mode = "AllowInternetOutbound"
     spark_ready    = true
@@ -72,10 +73,9 @@ module "aihub" {
 
   application_insights = {
     create_new = true
-  }
-
-  log_analytics_workspace = {
-    create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
   }
 
   enable_telemetry = var.enable_telemetry

--- a/examples/private_ai_studio/main.tf
+++ b/examples/private_ai_studio/main.tf
@@ -60,18 +60,10 @@ module "aihub" {
 
   key_vault = {
     create_new = true
-    network_acls = {
-      bypass         = "AzureServices"
-      default_action = "Deny"
-    }
   }
 
   storage_account = {
     create_new = true
-    network_rules = {
-      bypass         = ["Logging", "Metrics", "AzureServices"]
-      default_action = "Deny"
-    }
   }
 
   aiservices = {

--- a/examples/private_ai_studio/outputs.tf
+++ b/examples/private_ai_studio/outputs.tf
@@ -1,0 +1,5 @@
+output "resource" {
+  description = "The AI Studio hub workspace."
+  sensitive   = true
+  value       = module.aihub
+}

--- a/examples/private_managed_vnet/README.md
+++ b/examples/private_managed_vnet/README.md
@@ -1,0 +1,168 @@
+<!-- BEGIN_TF_DOCS -->
+# Private AML workspace with managed VNet configured
+
+This deploys the module with workspace isolation set to allow outbound Internet traffic. The resources include:
+
+- AML Workspace (private)
+- Storage Account (private)
+- Key Vault (private)
+- Azure Container Registry (private)
+- App Insights and Log Analytics workspace
+
+The managed VNet is not provisioned by default. In the unprovisioned state, you can see the outbound rules created in the Azure Portal or with the Azure CLI + machine learning extension `az ml workspace outbound-rule list --resource-group $RESOURCE_GROUP --workspace-name $WORKSPACE`. Since all possible provisioned resources are private, this collection should include one of type `PrivateEndpoint` for each of the following:
+
+- Key Vault
+- Storage Account: file (spark enabled)
+- Storage Account: blob (spark enabled)
+- Container Registry
+- AML Workspace (spark enabled)
+
+After the network is provisioned (either by adding compute or manually provisioning it with [the Azure CLI + machine learning extension](https://learn.microsoft.com/en-us/cli/azure/ml/workspace?view=azure-cli-latest#az-ml-workspace-provision-network)), the private endpoints themselves will be created internally for Azure Machine Learning.
+
+```hcl
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.115.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+}
+
+locals {
+  name = module.naming.machine_learning_workspace.name_unique
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "azureml" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location                = azurerm_resource_group.this.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.this.name
+  is_private              = true
+  workspace_friendly_name = "private-aml-workspace"
+  workspace_description   = "A private AML workspace"
+
+  workspace_managed_network = {
+    isolation_mode = "AllowInternetOutbound"
+  }
+
+  container_registry = {
+    create_new     = true
+    zone_redundant = false
+  }
+
+  application_insights = {
+    create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
+  }
+
+  enable_telemetry = false
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (=3.115.0)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.115.0/docs/resources/resource_group) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: The location for the resources.
+
+Type: `string`
+
+Default: `"uksouth"`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The machine learning workspace.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_azureml"></a> [azureml](#module\_azureml)
+
+Source: ../../
+
+Version:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/regions/azurerm
+
+Version: ~> 0.3
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/private_managed_vnet/_footer.md
+++ b/examples/private_managed_vnet/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/private_managed_vnet/_header.md
+++ b/examples/private_managed_vnet/_header.md
@@ -1,0 +1,19 @@
+# Private AML workspace with managed VNet configured
+
+This deploys the module with workspace isolation set to allow outbound Internet traffic. The resources include:
+
+- AML Workspace (private)
+- Storage Account (private)
+- Key Vault (private)
+- Azure Container Registry (private)
+- App Insights and Log Analytics workspace
+
+The managed VNet is not provisioned by default. In the unprovisioned state, you can see the outbound rules created in the Azure Portal or with the Azure CLI + machine learning extension `az ml workspace outbound-rule list --resource-group $RESOURCE_GROUP --workspace-name $WORKSPACE`. Since all possible provisioned resources are private, this collection should include one of type `PrivateEndpoint` for each of the following:
+
+- Key Vault
+- Storage Account: file (spark enabled)
+- Storage Account: blob (spark enabled)
+- Container Registry
+- AML Workspace (spark enabled)
+
+After the network is provisioned (either by adding compute or manually provisioning it with [the Azure CLI + machine learning extension](https://learn.microsoft.com/en-us/cli/azure/ml/workspace?view=azure-cli-latest#az-ml-workspace-provision-network)), the private endpoints themselves will be created internally for Azure Machine Learning.

--- a/examples/private_managed_vnet/main.tf
+++ b/examples/private_managed_vnet/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.115.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+}
+
+locals {
+  name = module.naming.machine_learning_workspace.name_unique
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "azureml" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location                = azurerm_resource_group.this.location
+  name                    = local.name
+  resource_group_name     = azurerm_resource_group.this.name
+  is_private              = true
+  workspace_friendly_name = "private-aml-workspace"
+  workspace_description   = "A private AML workspace"
+
+  workspace_managed_network = {
+    isolation_mode = "AllowInternetOutbound"
+  }
+
+  container_registry = {
+    create_new     = true
+    zone_redundant = false
+  }
+
+  application_insights = {
+    create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
+  }
+
+  enable_telemetry = false
+}

--- a/examples/private_managed_vnet/outputs.tf
+++ b/examples/private_managed_vnet/outputs.tf
@@ -1,0 +1,5 @@
+output "resource" {
+  description = "The machine learning workspace."
+  sensitive   = true
+  value       = module.azureml
+}

--- a/examples/private_managed_vnet/variables.tf
+++ b/examples/private_managed_vnet/variables.tf
@@ -1,0 +1,5 @@
+variable "location" {
+  type        = string
+  default     = "uksouth"
+  description = "The location for the resources."
+}

--- a/locals.tf
+++ b/locals.tf
@@ -2,10 +2,10 @@ locals {
   ai_services                = var.aiservices.create_new ? azapi_resource.aiservice[0].output : (var.aiservices.name != null && var.aiservices.resource_group_id != null) ? data.azapi_resource.existing_aiservices[0].output : null
   ai_services_id             = var.aiservices.create_new ? azapi_resource.aiservice[0].id : (var.aiservices.name != null && var.aiservices.resource_group_id != null) ? jsondecode(data.azapi_resource.existing_aiservices[0].output).id : null
   aml_resource               = var.kind == "Default" ? azapi_resource.this[0] : var.kind == "Hub" ? azapi_resource.hub[0] : azapi_resource.project[0]
-  application_insights_id    = var.application_insights.create_new ? replace(azurerm_application_insights.this[0].id, "Microsoft.Insights", "Microsoft.insights") : var.application_insights.resource_id
+  application_insights_id    = var.application_insights.create_new ? replace(module.avm_res_insights_component[0].resource_id, "Microsoft.Insights", "Microsoft.insights") : var.application_insights.resource_id
   container_registry_id      = var.container_registry.create_new ? module.avm_res_containerregistry_registry[0].resource_id : var.container_registry.resource_id
   key_vault_id               = var.key_vault.create_new ? replace(module.avm_res_keyvault_vault[0].resource_id, "Microsoft.KeyVault", "Microsoft.Keyvault") : var.key_vault.resource_id
-  log_analytics_workspace_id = var.log_analytics_workspace.create_new ? module.avm_res_log_analytics_workspace[0].resource_id : var.log_analytics_workspace.resource_id
+  log_analytics_workspace_id = var.application_insights.log_analytics_workspace.create_new ? module.avm_res_log_analytics_workspace[0].resource_id : var.application_insights.log_analytics_workspace.resource_id
   # application_insights_id = replace(azurerm_application_insights.this.id, "Microsoft.Insights", "Microsoft.insights")
   # Private endpoint application security group associations.
   # We merge the nested maps from private endpoints and application security group associations into a single map.
@@ -18,7 +18,6 @@ locals {
       }
     ]
   ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
-  resource_group_id                  = data.azurerm_resource_group.current.id
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
   # Resources that may or may not be created from this module
   storage_account_id = var.storage_account.create_new ? module.avm_res_storage_storageaccount[0].resource_id : var.storage_account.resource_id

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  ai_services                = var.aiservices.create_new ? module.avm_res_cognitiveservices_account[0].resource : var.aiservices.create_service_connection ? data.azapi_resource.existing_aiservices[0].output : null
-  ai_services_id             = var.aiservices.create_new ? module.avm_res_cognitiveservices_account[0].resource_id : var.aiservices.create_service_connection ? jsondecode(data.azapi_resource.existing_aiservices[0].output).id : null
+  ai_services                = var.aiservices.create_new ? azapi_resource.aiservice[0].output : var.aiservices.create_service_connection ? data.azapi_resource.existing_aiservices[0].output : null
+  ai_services_id             = var.aiservices.create_new ? azapi_resource.aiservice[0].id : var.aiservices.create_service_connection ? jsondecode(data.azapi_resource.existing_aiservices[0].output).id : null
   aml_resource               = var.kind == "Default" ? azapi_resource.this[0] : var.kind == "Hub" ? azapi_resource.hub[0] : azapi_resource.project[0]
   application_insights_id    = var.application_insights.create_new ? replace(module.avm_res_insights_component[0].resource_id, "Microsoft.Insights", "Microsoft.insights") : var.application_insights.resource_id
   container_registry_id      = var.container_registry.create_new ? module.avm_res_containerregistry_registry[0].resource_id : var.container_registry.resource_id

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  ai_services                = var.aiservices.create_new ? azapi_resource.aiservice[0].output : (var.aiservices.name != null && var.aiservices.resource_group_id != null) ? data.azapi_resource.existing_aiservices[0].output : null
-  ai_services_id             = var.aiservices.create_new ? azapi_resource.aiservice[0].id : (var.aiservices.name != null && var.aiservices.resource_group_id != null) ? jsondecode(data.azapi_resource.existing_aiservices[0].output).id : null
+  ai_services                = var.aiservices.create_new ? module.avm_res_cognitiveservices_account[0].resource : var.aiservices.create_service_connection ? data.azapi_resource.existing_aiservices[0].output : null
+  ai_services_id             = var.aiservices.create_new ? module.avm_res_cognitiveservices_account[0].resource_id : var.aiservices.create_service_connection ? jsondecode(data.azapi_resource.existing_aiservices[0].output).id : null
   aml_resource               = var.kind == "Default" ? azapi_resource.this[0] : var.kind == "Hub" ? azapi_resource.hub[0] : azapi_resource.project[0]
   application_insights_id    = var.application_insights.create_new ? replace(module.avm_res_insights_component[0].resource_id, "Microsoft.Insights", "Microsoft.insights") : var.application_insights.resource_id
   container_registry_id      = var.container_registry.create_new ? module.avm_res_containerregistry_registry[0].resource_id : var.container_registry.resource_id

--- a/main.appinsights.tf
+++ b/main.appinsights.tf
@@ -1,10 +1,12 @@
-resource "azurerm_application_insights" "this" {
-  count = var.application_insights.create_new ? 1 : 0
+module "avm_res_insights_component" {
+  source  = "Azure/avm-res-insights-component/azurerm"
+  version = "~> 0.1"
 
-  application_type    = "web"
   location            = var.location
-  name                = "app-insights-${var.name}"
   resource_group_name = var.resource_group_name
-  tags                = var.application_insights.tags == null ? var.tags : var.application_insights.tags == {} ? {} : var.application_insights.tags
+  name                = "app-insights-${var.name}"
   workspace_id        = local.log_analytics_workspace_id
+  tags                = var.application_insights.tags == null ? var.tags : var.application_insights.tags == {} ? {} : var.application_insights.tags
+
+  count = var.application_insights.create_new ? 1 : 0
 }

--- a/main.cognitiveservices.tf
+++ b/main.cognitiveservices.tf
@@ -16,7 +16,7 @@ resource "azapi_resource" "aiservice" {
   })
   location               = var.location
   name                   = "ai-svc-${var.name}"
-  parent_id              = local.resource_group_id
+  parent_id              = data.azurerm_resource_group.current.id
   response_export_values = ["*"]
   tags                   = var.aiservices.tags == null ? var.tags : var.aiservices.tags == {} ? {} : var.aiservices.tags
 

--- a/main.cognitiveservices.tf
+++ b/main.cognitiveservices.tf
@@ -1,40 +1,22 @@
-resource "azapi_resource" "aiservice" {
+module "avm_res_cognitiveservices_account" {
+  source  = "Azure/avm-res-cognitiveservices-account/azurerm"
+  version = "~> 0.1"
+
+  resource_group_name           = var.resource_group_name
+  kind                          = "CognitiveServices"
+  sku_name                      = var.aiservices.analysis_services_sku
+  name                          = "ai-svc-${var.name}"
+  location                      = var.location
+  public_network_access_enabled = var.is_private && var.kind != "Hub"
+  managed_identities = {
+    system_assigned = true
+  }
+  tags  = var.aiservices.tags == null ? var.tags : var.aiservices.tags == {} ? {} : var.aiservices.tags
   count = var.aiservices.create_new ? 1 : 0
-
-  type = "Microsoft.CognitiveServices/accounts@2024-04-01-preview"
-  body = jsonencode({
-    properties = {
-      publicNetworkAccess = (var.is_private && var.kind != "hub") ? "Disabled" : "Enabled" # Can't have private AI Services with private AI Studio hubs
-      apiProperties = {
-        statisticsEnabled = false
-      }
-    }
-    sku = {
-      "name" : var.aiservices.analysis_services_sku,
-    }
-    kind = "AIServices"
-  })
-  location               = var.location
-  name                   = "ai-svc-${var.name}"
-  parent_id              = data.azurerm_resource_group.current.id
-  response_export_values = ["*"]
-  tags                   = var.aiservices.tags == null ? var.tags : var.aiservices.tags == {} ? {} : var.aiservices.tags
-
-  identity {
-    type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      # When the service connection to the AI Studio Hub is created, 
-      # tags are added to this resource
-      tags,
-    ]
-  }
 }
 
 data "azapi_resource" "existing_aiservices" {
-  count = (var.aiservices.name != null && var.aiservices.resource_group_id != null) ? 1 : 0
+  count = !var.aiservices.create_new && var.aiservices.create_service_connection ? 1 : 0
 
   type                   = "Microsoft.CognitiveServices/accounts@2024-04-01-preview"
   name                   = var.aiservices.name

--- a/main.containerregistry.tf
+++ b/main.containerregistry.tf
@@ -6,7 +6,7 @@ module "avm_res_containerregistry_registry" {
   name                          = replace("acr${var.name}", "-", "")
   location                      = var.location
   resource_group_name           = var.resource_group_name
-  public_network_access_enabled = var.is_private ? false : true
+  public_network_access_enabled = !var.is_private
   zone_redundancy_enabled       = var.container_registry.zone_redundant
 
   private_endpoints = var.is_private && var.vnet != null ? {

--- a/main.keyvault.tf
+++ b/main.keyvault.tf
@@ -13,7 +13,7 @@ module "avm_res_keyvault_vault" {
     default_action = "Deny"
   } : null
 
-  public_network_access_enabled = var.is_private ? false : true
+  public_network_access_enabled = !var.is_private
 
   private_endpoints = var.is_private && var.vnet != null ? {
     for key, value in var.key_vault.private_endpoints :

--- a/main.keyvault.tf
+++ b/main.keyvault.tf
@@ -1,6 +1,6 @@
 module "avm_res_keyvault_vault" {
   source  = "Azure/avm-res-keyvault-vault/azurerm"
-  version = "0.8.0"
+  version = "~> 0.9.1"
 
   tenant_id           = data.azurerm_client_config.current.tenant_id
   enable_telemetry    = var.enable_telemetry
@@ -8,7 +8,10 @@ module "avm_res_keyvault_vault" {
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  network_acls = var.key_vault.network_acls
+  network_acls = var.is_private ? {
+    bypass         = "AzureServices"
+    default_action = "Deny"
+  } : null
 
   public_network_access_enabled = var.is_private ? false : true
 

--- a/main.loganalyticsworkspace.tf
+++ b/main.loganalyticsworkspace.tf
@@ -11,6 +11,6 @@ module "avm_res_log_analytics_workspace" {
     type = "SystemAssigned"
   }
 
-  tags  = var.log_analytics_workspace.tags == null ? var.tags : var.log_analytics_workspace.tags == {} ? {} : var.log_analytics_workspace.tags
-  count = var.log_analytics_workspace.create_new ? 1 : 0
+  tags  = var.application_insights.log_analytics_workspace.tags == null ? var.tags : var.application_insights.log_analytics_workspace.tags == {} ? {} : var.application_insights.log_analytics_workspace.tags
+  count = var.application_insights.log_analytics_workspace.create_new ? 1 : 0
 }

--- a/main.storage.tf
+++ b/main.storage.tf
@@ -85,7 +85,7 @@ module "avm_res_storage_storageaccount" {
     }]
   }
 
-  role_assignments = (var.is_private && ((var.aiservices.name != null && var.aiservices.resource_group_id != null) || var.aiservices.create_new)) ? {
+  role_assignments = (var.is_private && var.aiservices.create_service_connection) ? {
     "aiservices" = {
       role_definition_id_or_name       = "Storage Blob Data Contributor"
       principal_id                     = jsondecode(local.ai_services).identity.principalId

--- a/main.storage.tf
+++ b/main.storage.tf
@@ -7,7 +7,7 @@ module "avm_res_storage_storageaccount" {
   resource_group_name           = var.resource_group_name
   location                      = var.location
   shared_access_key_enabled     = true
-  public_network_access_enabled = var.is_private ? false : true
+  public_network_access_enabled = !var.is_private
 
   managed_identities = {
     system_assigned = true

--- a/main.storage.tf
+++ b/main.storage.tf
@@ -26,7 +26,10 @@ module "avm_res_storage_storageaccount" {
     }
   } : {}
 
-  network_rules = var.storage_account.network_rules
+  network_rules = var.is_private ? {
+    bypass         = ["Logging", "Metrics", "AzureServices"]
+    default_action = "Deny"
+  } : null
 
   # for idempotency
   blob_properties = {

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "azapi_resource" "this" {
   })
   location  = var.location
   name      = "aml-${var.name}"
-  parent_id = local.resource_group_id
+  parent_id = data.azurerm_resource_group.current.id
   tags      = var.tags
 
   identity {
@@ -56,7 +56,7 @@ resource "azapi_resource" "hub" {
   })
   location  = var.location
   name      = "hub-${var.name}"
-  parent_id = local.resource_group_id
+  parent_id = data.azurerm_resource_group.current.id
   tags      = var.tags
 
   identity {
@@ -87,7 +87,7 @@ resource "azapi_resource" "project" {
   })
   location  = var.location
   name      = "aihubproject-${var.name}"
-  parent_id = local.resource_group_id
+  parent_id = data.azurerm_resource_group.current.id
 
   identity {
     type = "SystemAssigned"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,8 @@ resource "azapi_resource" "this" {
       keyVault            = local.key_vault_id
       storageAccount      = local.storage_account_id
       containerRegistry   = local.container_registry_id
-      friendlyName        = var.is_private ? "AMLManagedVirtualNetwork" : "AMLPublic"
+      description         = var.workspace_description
+      friendlyName        = coalesce(var.workspace_friendly_name, (var.is_private ? "AMLManagedVirtualNetwork" : "AMLPublic"))
       managedNetwork = {
         isolationMode = var.workspace_managed_network.isolation_mode
         status = {
@@ -42,7 +43,8 @@ resource "azapi_resource" "hub" {
       keyVault            = local.key_vault_id
       storageAccount      = local.storage_account_id
       containerRegistry   = local.container_registry_id
-      friendlyName        = var.is_private ? "HubManagedVirtualNetwork" : "PublicHub"
+      description         = var.workspace_description
+      friendlyName        = coalesce(var.workspace_friendly_name, (var.is_private ? "HubManagedVirtualNetwork" : "PublicHub"))
       managedNetwork = {
         isolationMode = var.workspace_managed_network.isolation_mode
         status = {
@@ -77,8 +79,8 @@ resource "azapi_resource" "project" {
   type = "Microsoft.MachineLearningServices/workspaces@2024-04-01"
   body = jsonencode({
     properties = {
-      description   = "Azure AI PROJECT"
-      friendlyName  = "AI Project"
+      description   = var.workspace_description
+      friendlyName  = coalesce(var.workspace_friendly_name, "AI Project")
       hubResourceId = var.ai_studio_hub_id
     }
     kind = var.kind

--- a/main.tf
+++ b/main.tf
@@ -96,15 +96,15 @@ resource "azapi_resource" "project" {
 
 # AzAPI AI Services Connection
 resource "azapi_resource" "aiserviceconnection" {
-  count = var.aiservices.create_new || (var.aiservices.name != null && var.aiservices.resource_group_id != null) ? 1 : 0
+  count = var.aiservices.create_service_connection ? 1 : 0
 
   type = "Microsoft.MachineLearningServices/workspaces/connections@2024-04-01"
   body = jsonencode({
     properties = {
-      category      = "AIServices",
-      target        = jsondecode(local.ai_services).properties.endpoint,
-      authType      = "AAD",
-      isSharedToAll = true,
+      category      = "AIServices"
+      target        = jsondecode(local.ai_services).properties.endpoint
+      authType      = "AAD"
+      isSharedToAll = true
       metadata = {
         ApiType    = "Azure",
         ResourceId = local.ai_services_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "application_insights" {
   description = "The ID of the application insights."
-  value       = azurerm_application_insights.this
+  value       = length(module.avm_res_insights_component) == 1 ? module.avm_res_insights_component[0].resource : null
 }
 
 output "container_registry" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "1.14.0"
+      version = "1.15.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "aiservices" {
     create_new = false
   }
   description = <<DESCRIPTION
-An object describing the Application Insights resource to create or reference. This includes the following properties:
+An object describing the AI Services resource to create or reference. This includes the following properties:
 - `create_new`: (Optional) A flag indicating if a new resource must be created. If set to 'false', both `name` and `resource_group_id` must be provided.
 - `analysis_services_sku`: (Optional) When creating a new resource, this specifies the SKU of the Azure Analysis Services server. Possible values are: `D1`, `B1`, `B2`, `S0`, `S1`, `S2`, `S4`, `S8`, `S9`. Availability may be impacted by region; see https://learn.microsoft.com/en-us/azure/analysis-services/analysis-services-overview#availability-by-region
 - `name`: (Optional) If providing an existing resource, the name of the AI Services to reference
@@ -173,10 +173,6 @@ variable "key_vault" {
   type = object({
     resource_id = optional(string, null)
     create_new  = bool
-    network_acls = optional(object({
-      bypass         = optional(string, null)
-      default_action = optional(string, "Deny")
-    }))
     private_endpoints = optional(map(object({
       name                            = optional(string, null)
       subnet_resource_id              = optional(string, null)
@@ -194,9 +190,6 @@ variable "key_vault" {
 An object describing the Key Vault to create the private endpoint connection to. This includes the following properties:
 - `resource_id` - The resource ID of an existing Key Vault.
 - `create_new` -  A flag indicating if a new resource must be created.
-- `network_acls` - (Optional) An object to configure the Key Vault's network rules
-  - `bypass` - (Optional) Specifies whether traffic is bypassed for AzureServices. Valid options are 'AzureServices' or 'None'.
-  - `default_action` - `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are 'Deny' or 'Allow'. Defaults to 'Deny'.
 - `private_endpoints` - A map of private endpoints to create on a newly created Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
   - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
   - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
@@ -365,10 +358,6 @@ variable "storage_account" {
       network_interface_name          = optional(string, null)
       inherit_lock                    = optional(bool, false)
     })), {})
-    network_rules = optional(object({
-      bypass         = optional(set(string), [])
-      default_action = optional(string, "Deny")
-    }))
     tags = optional(map(string), null)
   })
   default = {
@@ -384,9 +373,6 @@ An object describing the Storage Account. This includes the following properties
   - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
   - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
   - `inherit_lock` - (Optional) If set to true, the private endpoint will inherit the lock from the parent resource. Defaults to false.
-- `network_rules` - (Optional) An object to configure the Storage Account's network rules
-  - `bypass` - (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of 'Logging', 'Metrics', 'AzureServices', or `None`.
-  - `default_action` - `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are 'Deny' or 'Allow'. Defaults to 'Deny'.
 - `tags` - (Optional) Tags for the Storage Account resource.
 DESCRIPTION
 
@@ -421,6 +407,18 @@ variable "vnet" {
 An object describing the Virtual Network to associate with the resource. This includes the following properties:
 - `resource_id` - The resource ID of the Virtual Network.
 DESCRIPTION
+}
+
+variable "workspace_description" {
+  type        = string
+  default     = null
+  description = "The description of this workspace."
+}
+
+variable "workspace_friendly_name" {
+  type        = string
+  default     = null
+  description = "The friendly name for this workspace. This value in mutable."
 }
 
 variable "workspace_managed_network" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,16 +72,13 @@ variable "application_insights" {
   })
   default = {
     create_new = false
-    log_analytics_workspace = {
-      create_new = false
-    }
   }
   description = <<DESCRIPTION
 An object describing the Application Insights resource to create or use. This includes the following properties:
 - `resource_id` - (Optional) The resource ID of an existing Application Insights resource.
 - `create_new` - A flag indicating if a new resource must be created.
 - `tags` - (Optional) Tags for a new Application Insights resource.
-- `log_analytics_workspace - An object describing the Log Analytics Workspace for the Application Insights resource
+- `log_analytics_workspace` - An object describing the Log Analytics Workspace for the Application Insights resource
   - `resource_id` - The resource ID of an existing Log Analytics Workspace.
   - `create_new` - A flag indicating if a new workspace must be created.
   - `tags` - (Optional) Tags for the Log Analytics Workspace resource.
@@ -89,7 +86,7 @@ DESCRIPTION
 
   validation {
     condition     = !(var.application_insights.create_new && var.application_insights.resource_id != null) && (var.application_insights.create_new == false || (var.application_insights.create_new == true && (var.application_insights.log_analytics_workspace.resource_id != null || var.application_insights.log_analytics_workspace.create_new)))
-    error_message = "If creating new App Insights resource, `resource_id` must be null and either `log_analytics_workspace.create_new` must be true or `log_analytics_workspace.resource_id` cannot be null"
+    error_message = "If creating a new Application Insights resource, `resource_id` must be null and either `log_analytics_workspace.create_new` must be true or `log_analytics_workspace.resource_id` must not be null"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,11 +33,12 @@ variable "ai_studio_hub_id" {
 
 variable "aiservices" {
   type = object({
-    create_new            = optional(bool, false)
-    analysis_services_sku = optional(string, "S0")
-    name                  = optional(string, null)
-    resource_group_id     = optional(string, null)
-    tags                  = optional(map(string), null)
+    create_new                = optional(bool, false)
+    analysis_services_sku     = optional(string, "S0")
+    name                      = optional(string, null)
+    resource_group_id         = optional(string, null)
+    tags                      = optional(map(string), null)
+    create_service_connection = optional(bool, false)
   })
   default = {
     create_new = false
@@ -48,7 +49,8 @@ An object describing the AI Services resource to create or reference. This inclu
 - `analysis_services_sku`: (Optional) When creating a new resource, this specifies the SKU of the Azure Analysis Services server. Possible values are: `D1`, `B1`, `B2`, `S0`, `S1`, `S2`, `S4`, `S8`, `S9`. Availability may be impacted by region; see https://learn.microsoft.com/en-us/azure/analysis-services/analysis-services-overview#availability-by-region
 - `name`: (Optional) If providing an existing resource, the name of the AI Services to reference
 - `resource_group_id`: (Optional) If providing an existing resource, the id of the resource group where the AI Services resource resides
-- `tags` - (Optional) Tags for the AI Services resource.
+- `tags`: (Optional) Tags for the AI Services resource.
+- `create_service_connection`: (Optional) Whether or not to create a service connection between the Workspace resource and AI Services resource.
 DESCRIPTION
 
   validation {


### PR DESCRIPTION
## Description

- Added variables for workspace friendly name and description
- Moved the Log Analytics Workspace variables under App Insights since it is only required when creating a new App Insights resource:
  - Either an existing `resource_id` is provided
  - Or the `create_new` flag is true and a new Log Analytics Workspace is created
- Added a variable for `create_service_connection` for `aiservices` to simplify the conditional logic and make it more flexible (connections can be made for workspaces with kind `Hub`, `Project` or `Default`)
- Added examples for the following scenarios:
  - Default AI Studio Hub
  - Private AML workspace using the managed VNet
  - BYO Resources for AI Studio Hub
- Update to use AVM module instead of the terraform resource provider for App Insights
- Various documentation fixes

Resolves #47 
Resolves #40 
Resolves #41 
Resolves #50 


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
