### PR TITLE
Make outbound rules configurable

### DIFF
--- a/deprecated_variables.tf
+++ b/deprecated_variables.tf
@@ -1,0 +1,14 @@
+variable "outbound_rules" {
+  type = map(object({
+    resource_id         = string
+    sub_resource_target = string
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+  A map of private endpoints outbound rules for the managed network. **This will be deprecated in favor of the `var.workspace_managed_network.outbound_rules` in a future release. Until then, the final outbound rules of type 'PrivateEndpoint' will be a combination of this variable's value and that of `workspace_managed_network.outbound_rules.private_endpoint`.
+
+  - `resource_id` - The resource id for the corresponding private endpoint.
+  - `sub_resource_target` - The sub_resource_target is target for the private endpoint. e.g. account for Openai, searchService for Azure Ai Search
+  
+  DESCRIPTION
+}

--- a/examples/private_ai_search/README.md
+++ b/examples/private_ai_search/README.md
@@ -1,0 +1,420 @@
+<!-- BEGIN_TF_DOCS -->
+# Private Workspace with AI Search
+
+This provisions Azure AI Search Service and deploys a private Azure Machine Learning Workspace with an outbound rule allowing connection to the Search Service over private endpoint.
+
+```hcl
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.116.0, < 4.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+  tags     = var.tags
+}
+
+module "virtual_network" {
+  source              = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version             = "0.7.0"
+  resource_group_name = azurerm_resource_group.this.name
+  subnets = {
+    private_endpoints = {
+      name                              = "private_endpoints"
+      address_prefixes                  = ["192.168.0.0/24"]
+      private_endpoint_network_policies = "Disabled"
+      service_endpoints                 = null
+    }
+  }
+  address_space = ["192.168.0.0/24"]
+  location      = var.location
+  name          = module.naming.virtual_network.name_unique
+  tags          = var.tags
+}
+
+module "private_dns_aml_api" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.api.azureml.ms"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.api.azureml.ms"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_aml_notebooks" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.notebooks.azure.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.notebooks.azureml.ms"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_keyvault_vault" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.vaultcore.azure.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.notebooks.azureml.ms"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_storageaccount_blob" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.blob.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.blob.core.windows.net"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_storageaccount_file" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.file.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.file.core.windows.net"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_containerregistry_registry" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.azurecr.io"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.azurecr.io"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_aisearch" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.search.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.search.windows.net"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "aisearch" {
+  source                        = "Azure/avm-res-search-searchservice/azurerm"
+  version                       = "0.1.3"
+  location                      = var.location
+  name                          = module.naming.search_service.name_unique
+  resource_group_name           = azurerm_resource_group.this.name
+  public_network_access_enabled = false
+  enable_telemetry              = var.enable_telemetry
+
+  private_endpoints = {
+    primary = {
+      subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+      private_dns_zone_resource_ids = [module.private_dns_aisearch.resource_id]
+      tags                          = var.tags
+    }
+  }
+
+  local_authentication_enabled = false
+  managed_identities = {
+    system_assigned = true
+  }
+  tags = var.tags
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "azureml" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location            = var.location
+  name                = module.naming.machine_learning_workspace.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  is_private          = true
+  workspace_managed_network = {
+    isolation_mode = "AllowOnlyApprovedOutbound"
+    outbound_rules = {
+      private_endpoint = {
+        aisearch = {
+          resource_id         = module.aisearch.resource_id
+          sub_resource_target = "searchService"
+        }
+      }
+    }
+  }
+  private_endpoints = {
+    primary = {
+      name                          = "pe-aml-workspace"
+      subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+      private_dns_zone_resource_ids = [module.private_dns_aml_api.resource_id, module.private_dns_aml_notebooks.resource_id]
+      inherit_lock                  = false
+    }
+  }
+
+  storage_account = {
+    create_new = true
+    private_endpoints = {
+      blob = {
+        name                          = "pe-storage-blob"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        subresource_name              = "blob"
+        private_dns_zone_resource_ids = [module.private_dns_storageaccount_blob.resource_id]
+        inherit_lock                  = false
+      }
+      file = {
+        name                          = "pe-storage-file"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        subresource_name              = "file"
+        private_dns_zone_resource_ids = [module.private_dns_storageaccount_file.resource_id]
+        inherit_lock                  = false
+      }
+    }
+  }
+
+  container_registry = {
+    create_new = true
+    private_endpoints = {
+      registry = {
+        name                          = "pe-containerregistry-regsitry"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        private_dns_zone_resource_ids = [module.private_dns_containerregistry_registry.resource_id]
+        inherit_lock                  = false
+      }
+    }
+  }
+
+  key_vault = {
+    create_new = true
+    private_endpoints = {
+      vault = {
+        name                          = "pe-keyvault-vault"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        private_dns_zone_resource_ids = [module.private_dns_keyvault_vault.resource_id]
+        inherit_lock                  = false
+      }
+    }
+  }
+
+  application_insights = {
+    create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
+  }
+
+  enable_telemetry = var.enable_telemetry
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0.0)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: The location for the resources.
+
+Type: `string`
+
+Default: `"eastus2"`
+
+### <a name="input_tags"></a> [tags](#input\_tags)
+
+Description: (Optional) Tags of the resource.
+
+Type: `map(string)`
+
+Default: `null`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: Relevant properties of the machine learning workspace and supporting resources.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_aisearch"></a> [aisearch](#module\_aisearch)
+
+Source: Azure/avm-res-search-searchservice/azurerm
+
+Version: 0.1.3
+
+### <a name="module_azureml"></a> [azureml](#module\_azureml)
+
+Source: ../../
+
+Version:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.4
+
+### <a name="module_private_dns_aisearch"></a> [private\_dns\_aisearch](#module\_private\_dns\_aisearch)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_private_dns_aml_api"></a> [private\_dns\_aml\_api](#module\_private\_dns\_aml\_api)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_private_dns_aml_notebooks"></a> [private\_dns\_aml\_notebooks](#module\_private\_dns\_aml\_notebooks)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_private_dns_containerregistry_registry"></a> [private\_dns\_containerregistry\_registry](#module\_private\_dns\_containerregistry\_registry)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_private_dns_keyvault_vault"></a> [private\_dns\_keyvault\_vault](#module\_private\_dns\_keyvault\_vault)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_private_dns_storageaccount_blob"></a> [private\_dns\_storageaccount\_blob](#module\_private\_dns\_storageaccount\_blob)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_private_dns_storageaccount_file"></a> [private\_dns\_storageaccount\_file](#module\_private\_dns\_storageaccount\_file)
+
+Source: Azure/avm-res-network-privatednszone/azurerm
+
+Version: 0.2.1
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/regions/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_virtual_network"></a> [virtual\_network](#module\_virtual\_network)
+
+Source: Azure/avm-res-network-virtualnetwork/azurerm
+
+Version: 0.7.0
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/private_ai_search/_footer.md
+++ b/examples/private_ai_search/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/private_ai_search/_header.md
+++ b/examples/private_ai_search/_header.md
@@ -1,0 +1,3 @@
+# Private Workspace with AI Search
+
+This provisions Azure AI Search Service and deploys a private Azure Machine Learning Workspace with an outbound rule allowing connection to the Search Service over private endpoint.

--- a/examples/private_ai_search/main.tf
+++ b/examples/private_ai_search/main.tf
@@ -1,0 +1,273 @@
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.116.0, < 4.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = module.naming.resource_group.name_unique
+  tags     = var.tags
+}
+
+module "virtual_network" {
+  source              = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version             = "0.7.0"
+  resource_group_name = azurerm_resource_group.this.name
+  subnets = {
+    private_endpoints = {
+      name                              = "private_endpoints"
+      address_prefixes                  = ["192.168.0.0/24"]
+      private_endpoint_network_policies = "Disabled"
+      service_endpoints                 = null
+    }
+  }
+  address_space = ["192.168.0.0/24"]
+  location      = var.location
+  name          = module.naming.virtual_network.name_unique
+  tags          = var.tags
+}
+
+module "private_dns_aml_api" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.api.azureml.ms"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.api.azureml.ms"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_aml_notebooks" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.notebooks.azure.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.notebooks.azureml.ms"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_keyvault_vault" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.vaultcore.azure.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.notebooks.azureml.ms"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_storageaccount_blob" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.blob.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.blob.core.windows.net"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_storageaccount_file" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.file.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.file.core.windows.net"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_containerregistry_registry" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.azurecr.io"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.azurecr.io"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "private_dns_aisearch" {
+  source              = "Azure/avm-res-network-privatednszone/azurerm"
+  version             = "0.2.1"
+  domain_name         = "privatelink.search.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+  virtual_network_links = {
+    dnslink = {
+      vnetlinkname = "privatelink.search.windows.net"
+      vnetid       = module.virtual_network.resource.id
+    }
+  }
+  tags             = var.tags
+  enable_telemetry = var.enable_telemetry
+}
+
+module "aisearch" {
+  source                        = "Azure/avm-res-search-searchservice/azurerm"
+  version                       = "0.1.3"
+  location                      = var.location
+  name                          = module.naming.search_service.name_unique
+  resource_group_name           = azurerm_resource_group.this.name
+  public_network_access_enabled = false
+  enable_telemetry              = var.enable_telemetry
+
+  private_endpoints = {
+    primary = {
+      subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+      private_dns_zone_resource_ids = [module.private_dns_aisearch.resource_id]
+      tags                          = var.tags
+    }
+  }
+
+  local_authentication_enabled = false
+  managed_identities = {
+    system_assigned = true
+  }
+  tags = var.tags
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "azureml" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  location            = var.location
+  name                = module.naming.machine_learning_workspace.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  is_private          = true
+  workspace_managed_network = {
+    isolation_mode = "AllowOnlyApprovedOutbound"
+    outbound_rules = {
+      private_endpoint = {
+        aisearch = {
+          resource_id         = module.aisearch.resource_id
+          sub_resource_target = "searchService"
+        }
+      }
+    }
+  }
+  private_endpoints = {
+    primary = {
+      name                          = "pe-aml-workspace"
+      subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+      private_dns_zone_resource_ids = [module.private_dns_aml_api.resource_id, module.private_dns_aml_notebooks.resource_id]
+      inherit_lock                  = false
+    }
+  }
+
+  storage_account = {
+    create_new = true
+    private_endpoints = {
+      blob = {
+        name                          = "pe-storage-blob"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        subresource_name              = "blob"
+        private_dns_zone_resource_ids = [module.private_dns_storageaccount_blob.resource_id]
+        inherit_lock                  = false
+      }
+      file = {
+        name                          = "pe-storage-file"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        subresource_name              = "file"
+        private_dns_zone_resource_ids = [module.private_dns_storageaccount_file.resource_id]
+        inherit_lock                  = false
+      }
+    }
+  }
+
+  container_registry = {
+    create_new = true
+    private_endpoints = {
+      registry = {
+        name                          = "pe-containerregistry-regsitry"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        private_dns_zone_resource_ids = [module.private_dns_containerregistry_registry.resource_id]
+        inherit_lock                  = false
+      }
+    }
+  }
+
+  key_vault = {
+    create_new = true
+    private_endpoints = {
+      vault = {
+        name                          = "pe-keyvault-vault"
+        subnet_resource_id            = module.virtual_network.subnets["private_endpoints"].resource_id
+        private_dns_zone_resource_ids = [module.private_dns_keyvault_vault.resource_id]
+        inherit_lock                  = false
+      }
+    }
+  }
+
+  application_insights = {
+    create_new = true
+    log_analytics_workspace = {
+      create_new = true
+    }
+  }
+
+  enable_telemetry = var.enable_telemetry
+}

--- a/examples/private_ai_search/outputs.tf
+++ b/examples/private_ai_search/outputs.tf
@@ -1,0 +1,5 @@
+output "resource" {
+  description = "Relevant properties of the machine learning workspace and supporting resources."
+  sensitive   = true
+  value       = module.azureml
+}

--- a/examples/private_ai_search/variables.tf
+++ b/examples/private_ai_search/variables.tf
@@ -1,0 +1,21 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "location" {
+  type        = string
+  default     = "eastus2"
+  description = "The location for the resources."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = null
+  description = "(Optional) Tags of the resource."
+}

--- a/main.tf
+++ b/main.tf
@@ -18,17 +18,7 @@ resource "azapi_resource" "this" {
         status = {
           sparkReady = var.workspace_managed_network.spark_ready
         }
-        outboundRules = {
-          for key, rule in var.outbound_rules : key => {
-            type = "PrivateEndpoint"
-            destination = {
-              serviceResourceId = rule.resource_id
-              subresourceTarget = rule.sub_resource_target
-              sparkEnabled      = false
-              sparkStatus       = "Inactive"
-            }
-          }
-        }
+        outboundRules = local.outbound_rules
       }
     }
     kind = var.kind
@@ -63,17 +53,7 @@ resource "azapi_resource" "hub" {
         status = {
           sparkReady = var.workspace_managed_network.spark_ready
         }
-        outboundRules = {
-          for key, rule in var.outbound_rules : key => {
-            type = "PrivateEndpoint"
-            destination = {
-              serviceResourceId = rule.resource_id
-              subresourceTarget = rule.sub_resource_target
-              sparkEnabled      = false
-              sparkStatus       = "Inactive"
-            }
-          }
-        }
+        outboundRules = local.outbound_rules
       }
     }
     kind = var.kind

--- a/variables.tf
+++ b/variables.tf
@@ -319,21 +319,6 @@ variable "managed_identities" {
   nullable    = false
 }
 
-variable "outbound_rules" {
-  type = map(object({
-    resource_id         = string
-    sub_resource_target = string
-  }))
-  default     = {}
-  description = <<DESCRIPTION
-  A map of private endpoints outbound rules for the managed network. **This will be deprecated in favor of the `var.workspace_managed_network.outbound_rules` in a future release. Until then, the final outbound rules of type 'PrivateEndpoint' will be a combination of this variable's value and that of `workspace_managed_network.outbound_rules.private_endpoint`.
-
-  - `resource_id` - The resource id for the corresponding private endpoint.
-  - `sub_resource_target` - The sub_resource_target is target for the private endpoint. e.g. account for Openai, searchService for Azure Ai Search
-  
-  DESCRIPTION
-}
-
 # required AVM interface
 variable "private_endpoints" {
   type = map(object({

--- a/variables.tf
+++ b/variables.tf
@@ -326,7 +326,7 @@ variable "outbound_rules" {
   }))
   default     = {}
   description = <<DESCRIPTION
-  A map of private endpoints toutbound rules for the managed network.
+  A map of private endpoints outbound rules for the managed network. **This will be deprecated in favor of the `var.workspace_managed_network.outbound_rules` in a future release. Until then, the final outbound rules of type 'PrivateEndpoint' will be a combination of this variable's value and that of `workspace_managed_network.outbound_rules.private_endpoint`.
 
   - `resource_id` - The resource id for the corresponding private endpoint.
   - `sub_resource_target` - The sub_resource_target is target for the private endpoint. e.g. account for Openai, searchService for Azure Ai Search
@@ -484,6 +484,23 @@ variable "workspace_managed_network" {
   type = object({
     isolation_mode = string
     spark_ready    = optional(bool, true)
+    outbound_rules = optional(object({
+      fqdn = optional(map(object({
+        destination = string
+      })), {})
+      private_endpoint = optional(map(object({
+        resource_id         = string
+        sub_resource_target = string
+        spark_enabled       = optional(bool, false)
+      })), {})
+      service_tag = optional(map(object({
+        action           = string
+        service_tag      = string
+        address_prefixes = optional(list(string), null)
+        protocol         = string
+        port_ranges      = string
+      })), {})
+    }), {})
   })
   default = {
     isolation_mode = "Disabled"
@@ -492,12 +509,44 @@ variable "workspace_managed_network" {
   description = <<DESCRIPTION
 Specifies properties of the workspace's managed virtual network.
 
-Possible values for `isolation_mode` are:
-- 'Disabled': Inbound and outbound traffic is unrestricted _or_ BYO VNet to protect resources.
-- 'AllowInternetOutbound': Allow all internet outbound traffic.
-- 'AllowOnlyApprovedOutbound': Outbound traffic is allowed by specifying service tags.
-While is possible to update the workspace to enable network isolation ('AllowInternetOutbound' or 'AllowOnlyApprovedOutbound'), it is not possible to disable it on a workspace with it enabled.
-
-`spark_ready` determines whether spark jobs will be run on the network. This value can be updated in the future.
+- `isolation_mode`: While is possible to update the workspace to enable network isolation (going from 'Disabled' to 'AllowInternetOutbound' or 'AllowOnlyApprovedOutbound'), it is not possible to disable it on a workspace with it enabled.
+  - 'Disabled': Inbound and outbound traffic is unrestricted _or_ BYO VNet to protect resources.
+  - 'AllowInternetOutbound': Allow all internet outbound traffic.
+  - 'AllowOnlyApprovedOutbound': Outbound traffic is allowed by specifying service tags.
+- `spark_ready` determines whether spark jobs will be run on the network. This value can be updated in the future.
+- `outbound_rules`: 
+  - `fqdn`: A map of FQDN rules. Only valid when `isolation_mode` is 'AllowOnlyApprovedOutbound'. **The inclusion of FQDN rules requires Azure Firewall to be deployed and used and cost will increase accordingly.
+    - `destination`: The allowed host name. Required. Examples: '*.anaconda.com' to install packages, 'pypi.org' to list dependencies, '*.tensorflow.org' for use with TensorFlow examples
+  - `private_endpoint`: A map of Private Endpoint rules.
+    - `resource_id`: The id of the resource with the private endpoint to enable the workspace to communicate with. Required.
+    - `sub_resource_target`: The specific target endpoint for the resource. Some Azure resources have only 1 option, while others will expose multiple. Required.
+    - `spark_enabled`: Whether to the endpoint should be Spark-enabled. This is primarily set 'true' if, and only if, `spark_ready` is true.
+  - `service_tag`: A map of Service Tag rules. Only valid when `isolation_mode` is 'AllowOnlyApprovedOutbound'.
+    - `action`: The networking rule to apply. Available options are 'Allow' or 'Deny'.
+    - `service_tag`: The target service tag.
+    - `address_prefixes`: Optional collection of address prefixes. If provided, `service_tag` will be ignored.
+    - `protocol`: The allowed protocol(s). Valid options dependent on Service Tag. 
+    - `port_ranges`: The allow port(s) / port ranges. Valid options dependent on Service Tag.
 DESCRIPTION
+
+  validation {
+    condition     = contains(["AllowOnlyApprovedOutbound", "AllowInternetOutbound", "Disabled"], var.workspace_managed_network.isolation_mode)
+    error_message = "The only valid options for `isolation_mode` are 'Disabled', 'AllowInternetOutbound' or 'AllowOnlyApprovedOutbound'."
+  }
+  validation {
+    condition     = length(var.workspace_managed_network.outbound_rules.fqdn) == 0 || alltrue([for _, v in var.workspace_managed_network.outbound_rules.fqdn : length(v.destination) > 0])
+    error_message = "`destination` is required for all FQDN outbound rules."
+  }
+  validation {
+    condition     = length(var.workspace_managed_network.outbound_rules.service_tag) == 0 || alltrue([for _, v in var.workspace_managed_network.outbound_rules.service_tag : contains(["Allow", "Deny"], v.action)])
+    error_message = "The only valid options for service tag outbound rules' `action` are 'Allow' or 'Deny'."
+  }
+  validation {
+    condition     = length(var.workspace_managed_network.outbound_rules.private_endpoint) == 0 || alltrue([for _, v in var.workspace_managed_network.outbound_rules.private_endpoint : length(v.resource_id) > 0])
+    error_message = "`resource_id` is required for every private endpoint outbound rule."
+  }
+  validation {
+    condition     = length(var.workspace_managed_network.outbound_rules.private_endpoint) == 0 || alltrue([for _, v in var.workspace_managed_network.outbound_rules.private_endpoint : length(v.sub_resource_target) > 0])
+    error_message = "`sub_resource_target` is required for every private endpoint outbound rule."
+  }
 }


### PR DESCRIPTION
## Description

As #97 included a question around the topic:
For hub & default workspaces, outbound rules are configurable. All types (fdqn, private endpoint, service tag) are supported. 

The description of the existing variable (`var.outbound_rules`) is updated to reflect that it will be deprecated in a future release. In the meantime, there is backward compatibility

Resolves #64

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [x] Feature update backwards compatible feature updates.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
