### PR TITLE
Pin ACR AVM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The following Modules are called:
 
 Source: Azure/avm-res-containerregistry-registry/azurerm
 
-Version: ~> 0.1
+Version: < 0.4.0
 
 ### <a name="module_avm_res_insights_component"></a> [avm\_res\_insights\_component](#module\_avm\_res\_insights\_component)
 

--- a/main.containerregistry.tf
+++ b/main.containerregistry.tf
@@ -1,7 +1,7 @@
 module "avm_res_containerregistry_registry" {
   source = "Azure/avm-res-containerregistry-registry/azurerm"
 
-  version = "~> 0.1"
+  version = "< 0.4.0"
 
   name                          = replace("acr${var.name}", "-", "")
   location                      = var.location


### PR DESCRIPTION
## Description

Pinned to < 0.4.0. This should prevent version conflict errors around azurerm v4

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
