### PR TITLE
Update azurerm provider and dependency

### DIFF
--- a/main.containerregistry.tf
+++ b/main.containerregistry.tf
@@ -1,7 +1,7 @@
 module "avm_res_containerregistry_registry" {
   source = "Azure/avm-res-containerregistry-registry/azurerm"
 
-  version = "< 0.4.0"
+  version = ">= 0.4.0"
 
   name                          = replace("acr${var.name}", "-", "")
   location                      = var.location

--- a/terraform.tf
+++ b/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0.0"
+      version = ">= 3.116.0, < 5.0.0"
     }
     modtm = {
       source  = "Azure/modtm"


### PR DESCRIPTION
## Description

Updates the azurerm provider to be greater than 4 which is consistently used by other modules. Bumps the ACR version which has also been updated to use azurerm >= 4.0.0.

Closes #105 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
