### PR TITLE
Support new property public_access_when_behind_vnet_enabled for AI Foundry Project

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "image": "mcr.microsoft.com/azterraform:avm-latest",
   "updateRemoteUserUID": true,
-  "containerUser": "1000",
   "runArgs": [],
   "mounts": [],
   "onCreateCommand": "terraform || true",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "image": "mcr.microsoft.com/azterraform:avm-latest",
   "updateRemoteUserUID": true,
+  "containerUser": "1000",
   "runArgs": [],
   "mounts": [],
   "onCreateCommand": "terraform || true",

--- a/README.md
+++ b/README.md
@@ -489,6 +489,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_public_access_when_behind_vnet_enabled"></a> [public\_access\_when\_behind\_vnet\_enabled](#input\_public\_access\_when\_behind\_vnet\_enabled)
+
+Description: (Optional) Whether to allow public access when behind VNet. Default is `false`
+
+Type: `bool`
+
+Default: `false`
+
 ### <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled)
 
 Description: (Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`

--- a/examples/hub_and_projects/README.md
+++ b/examples/hub_and_projects/README.md
@@ -189,7 +189,8 @@ module "aiproject" {
   managed_identities = {
     system_assigned = true
   }
-  workspace_friendly_name = each.value.friendlyName
+  public_access_when_behind_vnet_enabled = true
+  workspace_friendly_name                = each.value.friendlyName
 }
 ```
 

--- a/examples/hub_and_projects/main.tf
+++ b/examples/hub_and_projects/main.tf
@@ -175,6 +175,6 @@ module "aiproject" {
   managed_identities = {
     system_assigned = true
   }
-  workspace_friendly_name                = each.value.friendlyName
   public_access_when_behind_vnet_enabled = true
+  workspace_friendly_name                = each.value.friendlyName
 }

--- a/examples/hub_and_projects/main.tf
+++ b/examples/hub_and_projects/main.tf
@@ -175,5 +175,6 @@ module "aiproject" {
   managed_identities = {
     system_assigned = true
   }
-  workspace_friendly_name = each.value.friendlyName
+  workspace_friendly_name                = each.value.friendlyName
+  public_access_when_behind_vnet_enabled = true
 }

--- a/main.tf
+++ b/main.tf
@@ -146,9 +146,10 @@ resource "azapi_resource" "project" {
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
-      description   = var.workspace_description
-      friendlyName  = coalesce(var.workspace_friendly_name, "AI Project")
-      hubResourceId = var.azure_ai_hub.resource_id
+      allowPublicAccessWhenBehindVnet = var.public_access_when_behind_vnet_enabled
+      description                     = var.workspace_description
+      friendlyName                    = coalesce(var.workspace_friendly_name, "AI Project")
+      hubResourceId                   = var.azure_ai_hub.resource_id
     }
     kind = var.kind
   }

--- a/variables.tf
+++ b/variables.tf
@@ -346,16 +346,16 @@ variable "private_endpoints_manage_dns_zone_group" {
   nullable    = false
 }
 
-variable "public_network_access_enabled" {
-  type        = bool
-  default     = false
-  description = "(Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`"
-}
-
 variable "public_access_when_behind_vnet_enabled" {
   type        = bool
   default     = false
   description = "(Optional) Whether to allow public access when behind VNet. Default is `false`"
+}
+
+variable "public_network_access_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`"
 }
 
 # required AVM interface

--- a/variables.tf
+++ b/variables.tf
@@ -352,6 +352,12 @@ variable "public_network_access_enabled" {
   description = "(Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`"
 }
 
+variable "public_access_when_behind_vnet_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether to allow public access when behind VNet. Default is `false`"
+}
+
 # required AVM interface
 variable "role_assignments" {
   type = map(object({


### PR DESCRIPTION
## Description
This PR is to support new property [public_access_when_behind_vnet_enabled](https://github.com/Azure/azure-rest-api-specs/blob/6c2a7889cad5b66015f6d7448cc07179039ae8b1/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2025-06-01/workspaceRP.json#L1827) for AI Foundry Project.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
