### PR TITLE
Support new property provision_network_now_enabled for AI Foundry

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_provision_network_now_enabled"></a> [provision\_network\_now\_enabled](#input\_provision\_network\_now\_enabled)
+
+Description: (Optional) Whether sets to trigger the provisioning of the managed VNet with the default Options when creating a Workspace with the managed VNet enabled, or else it does nothing. Default is `false`
+
+Type: `bool`
+
+Default: `false`
+
 ### <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled)
 
 Description: (Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`

--- a/examples/hub_and_projects/README.md
+++ b/examples/hub_and_projects/README.md
@@ -131,6 +131,7 @@ module "aihub" {
     resource_id = azurerm_key_vault.example.id
   }
   kind                          = "Hub"
+  provision_network_now_enabled = false
   public_network_access_enabled = true
   storage_account = {
     resource_id = azurerm_storage_account.example.id
@@ -189,7 +190,8 @@ module "aiproject" {
   managed_identities = {
     system_assigned = true
   }
-  workspace_friendly_name = each.value.friendlyName
+  provision_network_now_enabled = false
+  workspace_friendly_name       = each.value.friendlyName
 }
 ```
 

--- a/examples/hub_and_projects/main.tf
+++ b/examples/hub_and_projects/main.tf
@@ -127,7 +127,7 @@ module "aihub" {
     isolation_mode = "Disabled"
     spark_ready    = false
   }
-  provision_network_now_enabled = true
+  provision_network_now_enabled = false
 }
 
 resource "azapi_resource" "aiservices_connection" {
@@ -177,5 +177,5 @@ module "aiproject" {
     system_assigned = true
   }
   workspace_friendly_name       = each.value.friendlyName
-  provision_network_now_enabled = true
+  provision_network_now_enabled = false
 }

--- a/examples/hub_and_projects/main.tf
+++ b/examples/hub_and_projects/main.tf
@@ -117,6 +117,7 @@ module "aihub" {
     resource_id = azurerm_key_vault.example.id
   }
   kind                          = "Hub"
+  provision_network_now_enabled = false
   public_network_access_enabled = true
   storage_account = {
     resource_id = azurerm_storage_account.example.id
@@ -127,7 +128,6 @@ module "aihub" {
     isolation_mode = "Disabled"
     spark_ready    = false
   }
-  provision_network_now_enabled = false
 }
 
 resource "azapi_resource" "aiservices_connection" {
@@ -176,6 +176,6 @@ module "aiproject" {
   managed_identities = {
     system_assigned = true
   }
-  workspace_friendly_name       = each.value.friendlyName
   provision_network_now_enabled = false
+  workspace_friendly_name       = each.value.friendlyName
 }

--- a/examples/hub_and_projects/main.tf
+++ b/examples/hub_and_projects/main.tf
@@ -127,6 +127,7 @@ module "aihub" {
     isolation_mode = "Disabled"
     spark_ready    = false
   }
+  provision_network_now_enabled = true
 }
 
 resource "azapi_resource" "aiservices_connection" {
@@ -175,5 +176,6 @@ module "aiproject" {
   managed_identities = {
     system_assigned = true
   }
-  workspace_friendly_name = each.value.friendlyName
+  workspace_friendly_name       = each.value.friendlyName
+  provision_network_now_enabled = true
 }

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,7 @@ resource "azapi_resource" "hub" {
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
+      provisionNetworkNow      = var.provision_network_now_enabled
       publicNetworkAccess      = local.enable_public_network_access ? "Enabled" : "Disabled"
       applicationInsights      = local.application_insights_id
       hbiWorkspace             = var.hbi_workspace
@@ -114,7 +115,8 @@ resource "azapi_resource" "hub" {
   ignore_casing  = true
   read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   replace_triggers_external_values = [
-    var.resource_group_name # since this is the value that determines if parent_id changes, require create/destroy if it changes
+    var.resource_group_name, # since this is the value that determines if parent_id changes, require create/destroy if it changes
+    var.provision_network_now_enabled
   ]
   tags           = var.tags
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -146,9 +148,10 @@ resource "azapi_resource" "project" {
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
-      description   = var.workspace_description
-      friendlyName  = coalesce(var.workspace_friendly_name, "AI Project")
-      hubResourceId = var.azure_ai_hub.resource_id
+      description         = var.workspace_description
+      friendlyName        = coalesce(var.workspace_friendly_name, "AI Project")
+      hubResourceId       = var.azure_ai_hub.resource_id
+      provisionNetworkNow = var.provision_network_now_enabled
     }
     kind = var.kind
   }
@@ -172,6 +175,9 @@ resource "azapi_resource" "project" {
       parent_id # because this comes from data, the azapi provider doesn't know it ahead of time which leads to destroy/recreate instead of update
     ]
   }
+  replace_triggers_external_values = [
+    var.provision_network_now_enabled
+  ]
 }
 
 resource "azurerm_management_lock" "this" {

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,9 @@ resource "azapi_resource" "project" {
   create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_external_values = [
+    var.provision_network_now_enabled
+  ]
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   dynamic "identity" {
@@ -175,9 +178,6 @@ resource "azapi_resource" "project" {
       parent_id # because this comes from data, the azapi provider doesn't know it ahead of time which leads to destroy/recreate instead of update
     ]
   }
-  replace_triggers_external_values = [
-    var.provision_network_now_enabled
-  ]
 }
 
 resource "azurerm_management_lock" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -346,16 +346,16 @@ variable "private_endpoints_manage_dns_zone_group" {
   nullable    = false
 }
 
-variable "public_network_access_enabled" {
-  type        = bool
-  default     = false
-  description = "(Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`"
-}
-
 variable "provision_network_now_enabled" {
   type        = bool
   default     = false
   description = "(Optional) Whether sets to trigger the provisioning of the managed VNet with the default Options when creating a Workspace with the managed VNet enabled, or else it does nothing. Default is `false`"
+}
+
+variable "public_network_access_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`"
 }
 
 # required AVM interface

--- a/variables.tf
+++ b/variables.tf
@@ -352,6 +352,12 @@ variable "public_network_access_enabled" {
   description = "(Optional) Whether (inbound) requests from the Internet / public network are allowed. Default is `false`"
 }
 
+variable "provision_network_now_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether sets to trigger the provisioning of the managed VNet with the default Options when creating a Workspace with the managed VNet enabled, or else it does nothing. Default is `false`"
+}
+
 # required AVM interface
 variable "role_assignments" {
   type = map(object({


### PR DESCRIPTION
## Description
This PR is to support new property [provision_network_now_enabled](https://github.com/Azure/azure-rest-api-specs/blob/6c2a7889cad5b66015f6d7448cc07179039ae8b1/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2025-06-01/workspaceRP.json#L1928) for AI Foundry.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
