### PR TITLE
removing pre-existing resource group requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ The following resources are used by this module:
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [azurerm_key_vault_key.cmk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_key) (data source)
-- [azurerm_resource_group.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/README.md
+++ b/README.md
@@ -140,12 +140,6 @@ Description: (Optional) The ID of the resource group where the ML workspace will
 
 Type: `string`
 
-### <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)
-
-Description: The resource group where the resources will be deployed.
-
-Type: `string`
-
 ## Optional Inputs
 
 The following input variables are optional (have default values):

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Type: `string`
 
 ### <a name="input_parent_id"></a> [parent\_id](#input\_parent\_id)
 
-Description: (Optional) The ID of the resource group where the ML workspace will be deployed.
+Description: (Required) The ID of the resource group where the ML workspace will be deployed.
 
 Type: `string`
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Description: The name of the this resource.
 
 Type: `string`
 
+### <a name="input_parent_id"></a> [parent\_id](#input\_parent\_id)
+
+Description: (Optional) The ID of the resource group where the ML workspace will be deployed.
+
+Type: `string`
+
 ### <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)
 
 Description: The resource group where the resources will be deployed.

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,3 @@
-data "azurerm_resource_group" "current" {
-  name = var.resource_group_name
-}
-
 data "azurerm_key_vault_key" "cmk" {
   count = var.customer_managed_key == null ? 0 : 1
 

--- a/examples/ai_hub_managed_key_vault/README.md
+++ b/examples/ai_hub_managed_key_vault/README.md
@@ -120,7 +120,7 @@ module "aihub" {
   # ...
   location                      = azurerm_resource_group.this.location
   name                          = "hub${random_string.name.id}"
-  resource_group_name           = azurerm_resource_group.this.name
+  parent_id                     = azurerm_resource_group.this.id
   enable_telemetry              = var.enable_telemetry
   key_vault                     = { use_microsoft_managed_key_vault = true }
   kind                          = "Hub"

--- a/examples/ai_hub_managed_key_vault/main.tf
+++ b/examples/ai_hub_managed_key_vault/main.tf
@@ -107,7 +107,7 @@ module "aihub" {
   # ...
   location                      = azurerm_resource_group.this.location
   name                          = "hub${random_string.name.id}"
-  resource_group_name           = azurerm_resource_group.this.name
+  parent_id                     = azurerm_resource_group.this.id
   enable_telemetry              = var.enable_telemetry
   key_vault                     = { use_microsoft_managed_key_vault = true }
   kind                          = "Hub"

--- a/examples/customer_managed_key/README.md
+++ b/examples/customer_managed_key/README.md
@@ -220,9 +220,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = azurerm_application_insights.this.id
   }

--- a/examples/customer_managed_key/main.tf
+++ b/examples/customer_managed_key/main.tf
@@ -186,9 +186,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = azurerm_application_insights.this.id
   }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -102,9 +102,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = provider::azurerm::normalise_resource_id(azurerm_application_insights.example.id)
   }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -88,9 +88,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = provider::azurerm::normalise_resource_id(azurerm_application_insights.example.id)
   }

--- a/examples/default_ai_hub/README.md
+++ b/examples/default_ai_hub/README.md
@@ -126,10 +126,10 @@ module "aihub" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.example.location
-  name                = "hub${random_string.name.id}"
-  resource_group_name = azurerm_resource_group.example.name
-  enable_telemetry    = var.enable_telemetry
+  location         = azurerm_resource_group.example.location
+  name             = "hub${random_string.name.id}"
+  parent_id        = azurerm_resource_group.example.id
+  enable_telemetry = var.enable_telemetry
   key_vault = {
     resource_id = azurerm_key_vault.example.id
   }

--- a/examples/default_ai_hub/main.tf
+++ b/examples/default_ai_hub/main.tf
@@ -112,10 +112,10 @@ module "aihub" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.example.location
-  name                = "hub${random_string.name.id}"
-  resource_group_name = azurerm_resource_group.example.name
-  enable_telemetry    = var.enable_telemetry
+  location         = azurerm_resource_group.example.location
+  name             = "hub${random_string.name.id}"
+  parent_id        = azurerm_resource_group.example.id
+  enable_telemetry = var.enable_telemetry
   key_vault = {
     resource_id = azurerm_key_vault.example.id
   }

--- a/examples/diagnostic_settings/README.md
+++ b/examples/diagnostic_settings/README.md
@@ -111,9 +111,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = azurerm_application_insights.example.id
   }

--- a/examples/diagnostic_settings/main.tf
+++ b/examples/diagnostic_settings/main.tf
@@ -96,9 +96,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = azurerm_application_insights.example.id
   }

--- a/examples/hub_and_projects/README.md
+++ b/examples/hub_and_projects/README.md
@@ -123,10 +123,10 @@ module "aihub" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.example.location
-  name                = "hub${random_string.name.id}"
-  resource_group_name = azurerm_resource_group.example.name
-  enable_telemetry    = var.enable_telemetry
+  location         = azurerm_resource_group.example.location
+  name             = "hub${random_string.name.id}"
+  parent_id        = azurerm_resource_group.example.id
+  enable_telemetry = var.enable_telemetry
   key_vault = {
     resource_id = azurerm_key_vault.example.id
   }
@@ -179,9 +179,9 @@ module "aiproject" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.example.location
-  name                = "proj${random_string.name.id}${each.key}"
-  resource_group_name = azurerm_resource_group.example.name
+  location  = azurerm_resource_group.example.location
+  name      = "proj${random_string.name.id}${each.key}"
+  parent_id = azurerm_resource_group.example.id
   azure_ai_hub = {
     resource_id = module.aihub.resource_id
   }

--- a/examples/hub_and_projects/main.tf
+++ b/examples/hub_and_projects/main.tf
@@ -109,10 +109,10 @@ module "aihub" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.example.location
-  name                = "hub${random_string.name.id}"
-  resource_group_name = azurerm_resource_group.example.name
-  enable_telemetry    = var.enable_telemetry
+  location         = azurerm_resource_group.example.location
+  name             = "hub${random_string.name.id}"
+  parent_id        = azurerm_resource_group.example.id
+  enable_telemetry = var.enable_telemetry
   key_vault = {
     resource_id = azurerm_key_vault.example.id
   }
@@ -165,9 +165,9 @@ module "aiproject" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.example.location
-  name                = "proj${random_string.name.id}${each.key}"
-  resource_group_name = azurerm_resource_group.example.name
+  location  = azurerm_resource_group.example.location
+  name      = "proj${random_string.name.id}${each.key}"
+  parent_id = azurerm_resource_group.example.id
   azure_ai_hub = {
     resource_id = module.aihub.resource_id
   }

--- a/examples/private_ai_hub/README.md
+++ b/examples/private_ai_hub/README.md
@@ -384,9 +384,9 @@ module "aihub" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = "hub${random_string.name.id}"
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = "hub${random_string.name.id}"
+  parent_id = azurerm_resource_group.this.id
   container_registry = {
     resource_id = module.avm_res_containerregistry_registry.resource_id
   }

--- a/examples/private_ai_hub/main.tf
+++ b/examples/private_ai_hub/main.tf
@@ -342,9 +342,9 @@ module "aihub" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = "hub${random_string.name.id}"
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = "hub${random_string.name.id}"
+  parent_id = azurerm_resource_group.this.id
   container_registry = {
     resource_id = module.avm_res_containerregistry_registry.resource_id
   }

--- a/examples/private_ai_search/README.md
+++ b/examples/private_ai_search/README.md
@@ -414,9 +414,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = var.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = var.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = module.avm_res_insights_component.resource_id
   }

--- a/examples/private_ai_search/main.tf
+++ b/examples/private_ai_search/main.tf
@@ -399,9 +399,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = var.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = var.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = module.avm_res_insights_component.resource_id
   }

--- a/examples/private_byo_vnet/README.md
+++ b/examples/private_byo_vnet/README.md
@@ -483,9 +483,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = var.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = var.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = module.avm_res_insights_component.resource_id
   }

--- a/examples/private_byo_vnet/main.tf
+++ b/examples/private_byo_vnet/main.tf
@@ -445,9 +445,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = var.location
-  name                = module.naming.machine_learning_workspace.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = var.location
+  name      = module.naming.machine_learning_workspace.name_unique
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = module.avm_res_insights_component.resource_id
   }

--- a/examples/private_managed_vnet/README.md
+++ b/examples/private_managed_vnet/README.md
@@ -493,9 +493,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = local.name
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = local.name
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = module.avm_res_insights_component.resource_id
   }

--- a/examples/private_managed_vnet/main.tf
+++ b/examples/private_managed_vnet/main.tf
@@ -446,9 +446,9 @@ module "azureml" {
 
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
-  location            = azurerm_resource_group.this.location
-  name                = local.name
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = local.name
+  parent_id = azurerm_resource_group.this.id
   application_insights = {
     resource_id = module.avm_res_insights_component.resource_id
   }

--- a/locals.tf
+++ b/locals.tf
@@ -54,6 +54,7 @@ locals {
         }
       }
   })
+  parsed_resource_id = provider::azapi::parse_resource_id(local.resource_type, var.parent_id)
   # Private endpoint application security group associations.
   # We merge the nested maps from private endpoints and application security group associations into a single map.
   private_endpoint_application_security_group_associations = { for assoc in flatten([
@@ -65,6 +66,8 @@ locals {
       }
     ]
   ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
+  resource_group_name                = local.parsed_resource_id["resource_group_name"]
+  resource_type                      = "Microsoft.Resources/resourceGroups"
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 }
 

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -3,7 +3,7 @@ resource "azurerm_private_endpoint" "this" {
 
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
-  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
+  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : local.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
   custom_network_interface_name = each.value.network_interface_name
   tags                          = each.value.tags
@@ -40,7 +40,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
 
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
-  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
+  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : local.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
   custom_network_interface_name = each.value.network_interface_name
   tags                          = each.value.tags

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "azapi_resource" "this" {
 
   location  = var.location
   name      = var.name
-  parent_id = var.resource_group_name
+  parent_id = var.parent_id
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
@@ -81,7 +81,7 @@ resource "azapi_resource" "hub" {
 
   location  = var.location
   name      = var.name
-  parent_id = var.resource_group_name
+  parent_id = var.parent_id
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
@@ -167,7 +167,7 @@ resource "azapi_resource" "project" {
 
   location  = var.location
   name      = var.name
-  parent_id = var.resource_group_name
+  parent_id = var.parent_id
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "azapi_resource" "this" {
   ignore_casing  = true
   read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   replace_triggers_external_values = [
-    var.resource_group_name # since this is the value that determines if parent_id changes, require create/destroy if it changes
+    local.resource_group_name # since this is the value that determines if parent_id changes, require create/destroy if it changes
   ]
   tags           = var.tags
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -129,7 +129,7 @@ resource "azapi_resource" "hub" {
   ignore_casing  = true
   read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   replace_triggers_external_values = [
-    var.resource_group_name, # since this is the value that determines if parent_id changes, require create/destroy if it changes
+    local.resource_group_name, # since this is the value that determines if parent_id changes, require create/destroy if it changes
     var.provision_network_now_enabled
   ]
   tags           = var.tags

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "azapi_resource" "this" {
 
   location  = var.location
   name      = var.name
-  parent_id = data.azurerm_resource_group.current.id
+  parent_id = var.resource_group_name
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
@@ -81,7 +81,7 @@ resource "azapi_resource" "hub" {
 
   location  = var.location
   name      = var.name
-  parent_id = data.azurerm_resource_group.current.id
+  parent_id = var.resource_group_name
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {
@@ -167,7 +167,7 @@ resource "azapi_resource" "project" {
 
   location  = var.location
   name      = var.name
-  parent_id = data.azurerm_resource_group.current.id
+  parent_id = var.resource_group_name
   type      = "Microsoft.MachineLearningServices/workspaces@2025-07-01-preview"
   body = {
     properties = {

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ DESCRIPTION
   }
 }
 
-# This is required for most resource modules
-variable "resource_group_name" {
-  type        = string
-  description = "The resource group where the resources will be deployed."
-}
-
 variable "application_insights" {
   type = object({
     resource_id = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,18 @@ variable "name" {
   }
 }
 
+variable "parent_id" {
+  type        = string
+  description = <<DESCRIPTION
+(Optional) The ID of the resource group where the ML workspace will be deployed.
+DESCRIPTION
+
+  validation {
+    condition     = can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+$", var.parent_id))
+    error_message = "parent_id must be a valid resource group ID."
+  }
+}
+
 # This is required for most resource modules
 variable "resource_group_name" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "name" {
 variable "parent_id" {
   type        = string
   description = <<DESCRIPTION
-(Optional) The ID of the resource group where the ML workspace will be deployed.
+(Required) The ID of the resource group where the ML workspace will be deployed.
 DESCRIPTION
 
   validation {


### PR DESCRIPTION
## Description

Removing the data call for resource group and var.resource_group_name, which causes issues when deploying from scratch, when a resource group does not exist. Aligning with AVM latest standard, main resource now using var.parent_id and changing references for var.resource_group_name to use local.resource_group_name, to avoid any resource taints/breaking changes.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
